### PR TITLE
SMSC 91x Ethernet driver port

### DIFF
--- a/core/arch/arm/dts/foundation-v8.dts
+++ b/core/arch/arm/dts/foundation-v8.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+
+/ {
+	model = "Foundation-v8A";
+	
+	motherboard {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "simple-bus";
+
+		eth@1a000000 { /* SMSC 91C111 ethernet */
+			compatible = "smc91x";
+			reg = <0x1a000000 0x10000>;
+			interrupts = <0 15 4>;
+		};
+	};
+};

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -24,6 +24,8 @@
 #include <tee/tee_cryp_utl.h>
 #include <tee/tee_fs_rpc.h>
 
+#include <drivers/smsc/smsc91x.h>
+
 static bool thread_prealloc_rpc_cache;
 static unsigned int thread_rpc_pnum;
 
@@ -273,6 +275,8 @@ static uint32_t std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2,
 			      uint32_t a3 __unused)
 {
 	const bool with_rpc_arg = true;
+
+	send_test_pkt();
 
 	switch (a0) {
 	case OPTEE_SMC_CALL_WITH_ARG:

--- a/core/arch/arm/kernel/thread_optee_smc.c
+++ b/core/arch/arm/kernel/thread_optee_smc.c
@@ -275,9 +275,9 @@ static uint32_t std_smc_entry(uint32_t a0, uint32_t a1, uint32_t a2,
 			      uint32_t a3 __unused)
 {
 	const bool with_rpc_arg = true;
-
+#if 0 
 	send_test_pkt();
-
+#endif
 	switch (a0) {
 	case OPTEE_SMC_CALL_WITH_ARG:
 		return std_entry_with_parg(reg_pair_to_64(a1, a2),

--- a/core/drivers/smsc/bstgw_eth_buf.c
+++ b/core/drivers/smsc/bstgw_eth_buf.c
@@ -133,6 +133,9 @@ bstgw_ethbuf_alloc_aligned(size_t capacity, size_t priv_size, size_t align_req)
 
     size_t rlen = (!align) ? capacity : roundup2(capacity, align_req) + align_req;
     size_t alloc_len = offsetof(bstgw_ethbuf_t, raw_buf[rlen]);
+
+    EMSG("BUFFER ALLOC: rlen = %u alloc_len =  %u", rlen, alloc_len);
+
     bstgw_ethbuf_t *eb = malloc(alloc_len);
     if(__predict_false( !eb )) return NULL;
 

--- a/core/drivers/smsc/bstgw_eth_buf.c
+++ b/core/drivers/smsc/bstgw_eth_buf.c
@@ -1,0 +1,293 @@
+#include <drivers/smsc/bstgw_eth_buf.h>
+
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include <kernel/panic.h>
+
+#include <drivers/smsc/utils.h>
+
+#include <drivers/smsc/npf_router.h>
+
+//#define BSTGW_ETHBUF_DEBUG
+
+/* ************************************************************************** */
+
+#include <kernel/spinlock.h>
+#include <initcall.h>
+
+struct ethbuf_pool {
+	unsigned int slock;
+	LIST_HEAD(, bstgw_ether_buffer) free_list;
+    LIST_HEAD(, bstgw_ether_buffer) inuse_list;
+    unsigned int capacity;
+};
+
+static struct ethbuf_pool ether_skb_pool;
+
+int bstgw_ethpool_init(void) {
+    ether_skb_pool.slock = SPINLOCK_UNLOCK;
+	LIST_INIT(&ether_skb_pool.free_list);
+    LIST_INIT(&ether_skb_pool.inuse_list);
+    ether_skb_pool.capacity = 0;
+    IMSG("ether_skb_pool is ready");
+    return TEE_SUCCESS;
+}
+//service_init(bstgw_ethpool_init);
+
+static bstgw_ethbuf_t *
+bstgw_ethbuf_alloc_aligned(size_t capacity, size_t priv_size, size_t aligned);
+static void bstgw_ethbuf_free(bstgw_ethbuf_t *eb);
+
+void bstgw_ethpool_increase(void *pool __unused, size_t buffer_number) {
+    bstgw_ethbuf_t *eb;
+    uint32_t exceptions = cpu_spin_lock_xsave(&ether_skb_pool.slock);
+    for(unsigned i=0; i<buffer_number; i++) {
+        eb = bstgw_ethbuf_alloc_aligned(BSTGW_DEFAULT_BUF_SIZE, BSTGW_PRIV_SIZE, BSTGW_CACHE_LINE);
+        if(!eb) panic("OOM @ ethpool_increase()"); // fixme
+        LIST_INSERT_HEAD(&ether_skb_pool.free_list, eb, pool_entry);
+    }
+    ether_skb_pool.capacity += buffer_number;
+    cpu_spin_unlock_xrestore(&ether_skb_pool.slock, exceptions);
+    //return 0;
+}
+
+static inline void bstgw_ethpool_buf_reset(bstgw_ethbuf_t *eb) {
+    assert(eb && !eb->next);
+    eb->l2_len = 0;
+    eb->l3_len = 0;
+    eb->data_len = 0;
+    eb->data_off = 0;
+
+    npf_mbuf_priv_t *p = (npf_mbuf_priv_t *)eb->priv_data;
+    p->flags = 0;
+
+    // todo: too expensive?!
+    //memset(eb->priv_data, 0, BSTGW_PRIV_SIZE); // todo: trim to minimum!
+}
+
+bstgw_ethbuf_t * bstgw_ethpool_buf_alloc(void *pool __unused) {
+    bstgw_ethbuf_t *eb;
+    uint32_t exceptions = cpu_spin_lock_xsave(&ether_skb_pool.slock);
+    eb = LIST_FIRST(&ether_skb_pool.free_list);
+    if(__predict_false( !eb )) panic("poll_buf_alloc OOM");
+    LIST_REMOVE(eb, pool_entry);
+    LIST_INSERT_HEAD(&ether_skb_pool.inuse_list, eb, pool_entry);
+    cpu_spin_unlock_xrestore(&ether_skb_pool.slock, exceptions);
+    //bstgw_ethpool_buf_reset(eb); // todo
+    return eb;
+}
+
+//TODO: eb with next != NULL
+void bstgw_ethpool_buf_free(bstgw_ethbuf_t *eb) {
+    assert(eb);
+    bstgw_ethpool_buf_reset(eb); // todo
+    uint32_t exceptions = cpu_spin_lock_xsave(&ether_skb_pool.slock);
+    LIST_REMOVE(eb, pool_entry);
+    LIST_INSERT_HEAD(&ether_skb_pool.free_list, eb, pool_entry);
+    cpu_spin_unlock_xrestore(&ether_skb_pool.slock, exceptions);
+}
+
+void bstgw_ethpool_buf_destroy(bstgw_ethbuf_t *eb) {
+    assert(eb);
+    uint32_t exceptions = cpu_spin_lock_xsave(&ether_skb_pool.slock);
+    LIST_REMOVE(eb, pool_entry);
+    ether_skb_pool.capacity--;
+    cpu_spin_unlock_xrestore(&ether_skb_pool.slock, exceptions);
+    bstgw_ethbuf_free(eb);
+}
+
+
+/* ************************************************************************** */
+
+void bstgw_ethbuf_align_check(bstgw_ethbuf_t *eb) {
+    assert(eb);
+    if(__predict_false( (int)eb->buf & eb->aligned ))
+        panic("Failed to properly align ethbuf");
+}
+
+static inline void * bstgw_ethpool_alloc_priv(size_t priv_size) {
+    /*
+     * usually very small, so calloc() should be fine ...
+     * but in general it prob. should be malloc() instead
+     * with the priv-owner initing it as required
+     */
+    return calloc(1, priv_size);
+}
+
+unsigned power_ceil(unsigned x) {
+    if (x <= 1) return 1;
+    int power = 2;
+    x--;
+    while (x >>= 1) power <<= 1;
+    return power;
+}
+
+
+#define roundup2(x, size) ( (((uintptr_t)(x)) + size-1)  & (~(size-1)) )
+
+static bstgw_ethbuf_t *
+bstgw_ethbuf_alloc_aligned(size_t capacity, size_t priv_size, size_t align_req)
+{
+    bool align = (align_req != 0);
+
+    size_t rlen = (!align) ? capacity : roundup2(capacity, align_req) + align_req;
+    size_t alloc_len = offsetof(bstgw_ethbuf_t, raw_buf[rlen]);
+    bstgw_ethbuf_t *eb = malloc(alloc_len);
+    if(__predict_false( !eb )) return NULL;
+
+    // init everything except of data buffer with 0s
+    memset(eb, 0, sizeof(bstgw_ethbuf_t));
+    eb->buf_cap = capacity;
+    eb->aligned = align_req - 1;
+    eb->buf = eb->raw_buf;
+
+    // pre-pad for alignment
+    if (align) {
+        size_t off = ((unsigned long)eb->raw_buf) & eb->aligned;
+        if (off) eb->buf = &eb->raw_buf[eb->aligned + 1 - off];
+        bstgw_ethbuf_align_check(eb);
+    }
+
+    if (__predict_true(priv_size > 0)) {
+        eb->priv_data = bstgw_ethpool_alloc_priv(priv_size);
+        if (__predict_false(!eb->priv_data)) {
+            free(eb);
+            return NULL;
+        }
+    }
+    return eb;
+}
+
+
+static void bstgw_ethbuf_free(bstgw_ethbuf_t *eb) {
+    if (__predict_false(!eb)) return;
+    bstgw_ethbuf_t *next;
+    while (eb) {
+        next = eb->next;
+        if (eb->priv_data) free(eb->priv_data);
+        free(eb);
+        eb = next;
+    }
+}
+
+
+// capacity of the buffer
+size_t bstgw_ethbuf_buf_capacity(const bstgw_ethbuf_t *eb) {
+    assert(eb);
+    return eb->buf_cap;
+}
+
+// data/payload length of the buffer
+size_t bstgw_ethbuf_data_len(const bstgw_ethbuf_t *eb) {
+    assert(eb);
+    return eb->data_len;
+}
+
+// total length of packet buffer chain
+size_t bstgw_ethbuf_total_pkt_len(const bstgw_ethbuf_t *eb) {
+    assert(eb);
+    // predict true, bcs. we currently do not use chaining, yet
+    if (__predict_true(!eb->next)) return eb->data_len;
+    size_t len = 0;
+    while (eb) {
+        len += eb->data_len;
+        eb = eb->next;
+    }
+    return len;
+}
+
+void * bstgw_ethbuf_priv(const bstgw_ethbuf_t *eb) {
+    assert(eb);
+    return eb->priv_data;
+}
+
+// pointer to buffer head
+uint8_t * bstgw_ethbuf_head(const bstgw_ethbuf_t *eb) {
+    assert(eb);
+    return (bstgw_ethbuf_t *)eb->buf;
+}
+
+// pointer to data[offset]
+uint8_t * bstgw_ethbuf_data_ptr(const bstgw_ethbuf_t *eb, size_t offset) {
+    assert(eb);
+    if (__predict_false( offset >= eb->data_len )) return NULL;
+    assert ( (eb->data_off + offset) < eb->buf_cap );
+    return &((bstgw_ethbuf_t *)eb)->buf[eb->data_off + offset];
+}
+
+// try to linearize the chain
+int bstgw_ethbuf_linearize(bstgw_ethbuf_t *eb) {
+    if(__predict_false(!eb)) return -1;
+    // predict true, bcs. we currently do not use chaining, yet
+    if(__predict_true(!eb->next)) return 0;
+
+    // enough free space?
+    size_t tail_space = eb->buf_cap - (eb->data_off + eb->data_len);
+    size_t rest_buf = bstgw_ethbuf_total_pkt_len(eb) - eb->data_len;
+    if(__predict_false( tail_space < rest_buf )) return -1;
+
+    // copy and free loop
+    uint8_t *b = bstgw_ethbuf_data_ptr(eb, eb->data_len - 1); // point at last data byte
+    b++; // now points just after current data
+    
+    bstgw_ethbuf_t *next = eb->next;
+    while (next) {
+        bstgw_ethbuf_t *tmp = next->next;
+        memcpy(b, bstgw_ethbuf_data_ptr(next, 0), next->data_len);
+        b += next->data_len;
+        free(next); // only the eb, not the chain!
+        next = tmp;
+    }
+
+    eb->data_len += rest_buf;
+    eb->next = NULL;
+    return 0;
+}
+
+/* Warning
+ * This function is highly incomplete.
+ * Because of alignment issues, this is just used for replacing ethernet headers atm.
+ * Also be careful when the buffer length drops to because of that function.
+ */
+uint8_t * bstgw_ethbuf_precut(bstgw_ethbuf_t *eb, size_t len) {
+    if(__predict_false(!eb)) return NULL;
+    if(__predict_false(len > eb->data_len)) return NULL;
+
+    eb->data_off += len;
+    eb->data_len -= len;
+    return &eb->buf[eb->data_off];
+}
+
+/* Warning
+ * This function is highly incomplete.
+ * Because of alignment issues, this is just used for replacing ethernet headers atm.
+ */
+uint8_t * bstgw_ethbuf_prepend(bstgw_ethbuf_t *eb, size_t len) {
+    if(__predict_false(!eb)) return NULL;
+    
+    size_t head_space = eb->data_off;
+    if(__predict_false( head_space < len )) return NULL;
+
+    eb->data_off -= len;
+    eb->data_len += len;
+    return &eb->buf[eb->data_off];
+}
+
+void bstgw_ethbuf_dump_meta(bstgw_ethbuf_t *eb) {
+    if(__predict_false(!eb)) return;
+    DMSG("Buffer metadata:");
+    DMSG("cap: %u, doff: %u, dlen: %u",
+        eb->buf_cap, eb->data_off, eb->data_len);
+}
+
+void bstgw_ethbuf_dump_data(bstgw_ethbuf_t *eb) {
+    if(__predict_false(!eb)) return;
+    DMSG("Buffer data dump:");
+    while(eb) {
+        for (unsigned int i=0; i<eb->data_len; i++) {
+            DMSG("0x%x", *bstgw_ethbuf_data_ptr(eb, i));
+        }
+        eb = eb->next;
+    }
+}

--- a/core/drivers/smsc/smsc91x.c
+++ b/core/drivers/smsc/smsc91x.c
@@ -8,26 +8,33 @@
 
 #include <assert.h>
 #include <drivers/smsc/smsc91x.h>
-#include <drivers/rtc.h>
-#include <io.h>
+#include <config.h>
+#include <initcall.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <libfdt.h>
+#include <malloc.h>
+#include <sys/queue.h>
+#include <tee_api_defines_extensions.h>
+#include <tee_api_types.h>
 
 
-static int
-smsc91x_probe(const void *fdt __unused, struct device *dev, const void *data) {
+static TEE_Result
+smsc91x_probe(const void *fdt __unused, int dev, const void *data) {
 	EMSG("SMSC bitches!!!!!");
 	return 0;
 }
 
 
 static const struct dt_device_match smsc91x_match_table[] = {
-	{ .compatible = "smsc" },
+	{ .compatible = "smc91x", },
 	{ }
 };
 
-DEFINE_DT_DRIVER(smsc91x_dt_driver) = {
-	.name = "smc",
+DEFINE_DT_DRIVER(smc_dt_driver) = {
+	.name = "smc91x",
 	.type = DT_DRIVER_NOTYPE,
 	.match_table = smsc91x_match_table,
 	.probe = smsc91x_probe,
 };
+

--- a/core/drivers/smsc/smsc91x.c
+++ b/core/drivers/smsc/smsc91x.c
@@ -1,0 +1,33 @@
+/*
+ * smsc91x.c
+ *
+ *  Created on: Nov 10, 2022
+ *      Author: rami
+ */
+
+
+#include <assert.h>
+#include <drivers/smsc/smsc91x.h>
+#include <drivers/rtc.h>
+#include <io.h>
+#include <kernel/dt.h>
+
+
+static int
+smsc91x_probe(const void *fdt __unused, struct device *dev, const void *data) {
+	EMSG("SMSC bitches!!!!!");
+	return 0;
+}
+
+
+static const struct dt_device_match smsc91x_match_table[] = {
+	{ .compatible = "smsc" },
+	{ }
+};
+
+DEFINE_DT_DRIVER(smsc91x_dt_driver) = {
+	.name = "smc",
+	.type = DT_DRIVER_NOTYPE,
+	.match_table = smsc91x_match_table,
+	.probe = smsc91x_probe,
+};

--- a/core/drivers/smsc/smsc91x.c
+++ b/core/drivers/smsc/smsc91x.c
@@ -17,14 +17,157 @@
 #include <sys/queue.h>
 #include <tee_api_defines_extensions.h>
 #include <tee_api_types.h>
+#include <drivers/smsc/errno.h>
+#include <io.h>
+
+#ifndef SMC_NOWAIT
+# define SMC_NOWAIT		0
+#endif
+
+struct platform_device_id {
+    char name[20];
+    unsigned long driver_data;
+};
+
+static struct smc_local * smsc = NULL;
+static int nowait = SMC_NOWAIT;
+static const char version[] =
+	"smc91x.c: v1.1, sep 22 2004 by Nicolas Pitre <nico@fluxnic.net>\n";
+static const char * chip_ids[ 16 ] =  {
+	NULL, NULL, NULL,
+	/* 3 */ "SMC91C90/91C92",
+	/* 4 */ "SMC91C94",
+	/* 5 */ "SMC91C95",
+	/* 6 */ "SMC91C96",
+	/* 7 */ "SMC91C100",
+	/* 8 */ "SMC91C100FD",
+	/* 9 */ "SMC91C11xFD",
+	NULL, NULL, NULL,
+	NULL, NULL, NULL};
+
+static TEE_Result init_eth();
+static TEE_Result smc_probe(void  *ioaddr);
 
 
 static TEE_Result
 smsc91x_probe(const void *fdt __unused, int dev, const void *data) {
-	EMSG("SMSC bitches!!!!!");
-	return 0;
+	EMSG("SMSC probe()");
+
+	const struct platform_device_id *smsc_id_data;
+	int ret = 0;
+
+	smsc = malloc(sizeof(struct smc_local));
+	if (!smsc)
+		return -ENOMEM;
+
+	smsc_id_data = data;
+
+	EMSG("SMSC device name: %s", smsc_id_data->name);
+
+	paddr_t pa = _fdt_reg_base_address(fdt, 1);
+	size_t size = 0;
+
+	ret = dt_map_dev(fdt, dev, &pa, &size, DT_MAP_SECURE);
+
+	EMSG("SMSC device addr: %lx, %i %x", pa, ret, size);
+
+	smsc->cfg.flags |= (SMC_CAN_USE_8BIT)  ? SMC91X_USE_8BIT  : 0;
+	smsc->cfg.flags |= (SMC_CAN_USE_16BIT) ? SMC91X_USE_16BIT : 0;
+	smsc->cfg.flags |= (SMC_CAN_USE_32BIT) ? SMC91X_USE_32BIT : 0;
+	smsc->cfg.flags |= (nowait) ? SMC91X_NOWAIT : 0;
+
+	smsc->io_shift = SMC91X_IO_SHIFT(smsc->cfg.flags);
+
+	ret = smc_probe(pa);
+
+
+	init_eth();
+
+	return ret;
 }
 
+static TEE_Result smc_probe(void  *ioaddr)
+{
+	static int version_printed = 0;
+	int retval;
+	unsigned int val, revision_register;
+	const char *version_string;
+
+	DMSG("%s: %s", CARDNAME, __func__);
+
+	/* First, see if the high byte is 0x33 */
+	val = SMC_CURRENT_BANK(smsc);
+	DMSG("%s: bank signature probe returned 0x%04x", CARDNAME, val);
+	if ((val & 0xFF00) != 0x3300) {
+		if ((val & 0xFF) == 0x33) {
+			DMSG(
+				"%s: Detected possible byte-swapped interface"
+				" at IOADDR %p", CARDNAME, ioaddr);
+		}
+		retval = -ENODEV;
+		goto err_out;
+	}
+
+	/*
+	 * The above MIGHT indicate a device, but I need to write to
+	 * further test this.
+	 */
+	SMC_SELECT_BANK(smsc, 0);
+	val = SMC_CURRENT_BANK(smsc);
+	if ((val & 0xFF00) != 0x3300) {
+		retval = -ENODEV;
+		goto err_out;
+	}
+
+	/*
+	 * well, we've already written once, so hopefully another
+	 * time won't hurt.  This time, I need to switch the bank
+	 * register to bank 1, so I can access the base address
+	 * register
+	 */
+	SMC_SELECT_BANK(smsc, 1);
+	val = SMC_GET_BASE(smsc);
+	val = ((val & 0x1F00) >> 3) << SMC_IO_SHIFT;
+	if (((unsigned long)ioaddr & (0x3e0 << SMC_IO_SHIFT)) != val) {
+		DMSG("%s: IOADDR %p doesn't match configuration (%x).",
+			CARDNAME, ioaddr, val);
+	}
+
+	/*
+	 * check if the revision register is something that I
+	 * recognize.  These might need to be added to later,
+	 * as future revisions could be added.
+	 */
+	SMC_SELECT_BANK(smsc, 3);
+	revision_register = SMC_GET_REV(smsc);
+	DMSG("%s: revision = 0x%04x", CARDNAME, revision_register);
+	version_string = chip_ids[ (revision_register >> 4) & 0xF];
+	if (!version_string || (revision_register & 0xff00) != 0x3300) {
+		/* I don't recognize this chip, so... */
+		DMSG("%s: IO %p: Unrecognized revision register 0x%04x"
+			", Contact author.", CARDNAME,
+			ioaddr, revision_register);
+
+		retval = -ENODEV;
+		goto err_out;
+	}
+
+	/* At this point I'll assume that the chip is an SMC91x. */
+	if (version_printed++ == 0)
+		DMSG("%s", version);
+
+
+	return TEE_SUCCESS;
+
+	err_out:
+		EMSG( "SMC probe failed");
+		return retval;
+}
+
+TEE_Result init_eth()
+{
+	return TEE_SUCCESS;
+}
 
 static const struct dt_device_match smsc91x_match_table[] = {
 	{ .compatible = "smc91x", },

--- a/core/drivers/smsc/sub.mk
+++ b/core/drivers/smsc/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += smsc91x.c

--- a/core/drivers/smsc/sub.mk
+++ b/core/drivers/smsc/sub.mk
@@ -1,1 +1,2 @@
 srcs-y += smsc91x.c
+srcs-y += bstgw_eth_buf.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -69,6 +69,7 @@ subdirs-$(CFG_BNXT_FW) += bnxt
 subdirs-$(CFG_DRIVERS_CLK) += clk
 subdirs-$(CFG_DRIVERS_RSTCTRL) += rstctrl
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
+subdirs-y += smsc 
 subdirs-y += imx
 subdirs-y += pm
 subdirs-y += wdt

--- a/core/include/drivers/smsc/bstgw_eth_buf.h
+++ b/core/include/drivers/smsc/bstgw_eth_buf.h
@@ -65,26 +65,25 @@ typedef struct bstgw_ether_buffer bstgw_ethbuf_t;
 
 
 // capacity of the buffer
-inline size_t bstgw_ethbuf_buf_capacity(const bstgw_ethbuf_t *);
+size_t bstgw_ethbuf_buf_capacity(const bstgw_ethbuf_t *);
 
 // data/payload length of the buffer
-inline size_t bstgw_ethbuf_data_len(const bstgw_ethbuf_t *);
+size_t bstgw_ethbuf_data_len(const bstgw_ethbuf_t *);
 
 // total length of packet buffer chain
 size_t bstgw_ethbuf_total_pkt_len(const bstgw_ethbuf_t *);
 
-inline void * bstgw_ethbuf_priv(const bstgw_ethbuf_t *);
+void * bstgw_ethbuf_priv(const bstgw_ethbuf_t *);
 
 // pointer to buffer head
-inline uint8_t * bstgw_ethbuf_head(const bstgw_ethbuf_t *);
+uint8_t * bstgw_ethbuf_head(const bstgw_ethbuf_t *);
 
-// pointer to data[offset]
-inline uint8_t * bstgw_ethbuf_data_ptr(const bstgw_ethbuf_t *, size_t);
-
-inline void bstgw_ethbuf_align_check(bstgw_ethbuf_t *);
 
 // try to linearize the chain
 int bstgw_ethbuf_linearize(bstgw_ethbuf_t *);
+
+// pointer to data[offset]
+uint8_t * bstgw_ethbuf_data_ptr(const bstgw_ethbuf_t *, size_t);
 
 /* bstgw_ethbuf_precut
  * Remove space from start of data.
@@ -97,7 +96,11 @@ int bstgw_ethbuf_linearize(bstgw_ethbuf_t *);
  */
 // cut from start of data
 // returns pointer to new start of data
-inline uint8_t * bstgw_ethbuf_precut(bstgw_ethbuf_t *, size_t);
+uint8_t * bstgw_ethbuf_precut(bstgw_ethbuf_t *, size_t);
+
+
+void bstgw_ethbuf_align_check(bstgw_ethbuf_t *);
+
 
 /* bstgw_ethbuf_prepend
  * Add new space to start of data.
@@ -107,7 +110,7 @@ inline uint8_t * bstgw_ethbuf_precut(bstgw_ethbuf_t *, size_t);
  * This function is highly incomplete.
  * Because of alignment issues, this is just used for replacing ethernet headers atm.
  */
-inline uint8_t * bstgw_ethbuf_prepend(bstgw_ethbuf_t *, size_t);
+uint8_t * bstgw_ethbuf_prepend(bstgw_ethbuf_t *, size_t);
 
 // TODO: add to/remove from chain
 

--- a/core/include/drivers/smsc/bstgw_eth_buf.h
+++ b/core/include/drivers/smsc/bstgw_eth_buf.h
@@ -128,4 +128,6 @@ void bstgw_ethpool_buf_free(bstgw_ethbuf_t *eb);
 /* Destroy a buffer, i.e., remove it from the pool and free its memory */
 void bstgw_ethpool_buf_destroy(bstgw_ethbuf_t *eb);
 
+int bstgw_ethpool_init(void);
+
 #endif /* __BSTGW_ETH_BUF_H */

--- a/core/include/drivers/smsc/bstgw_eth_buf.h
+++ b/core/include/drivers/smsc/bstgw_eth_buf.h
@@ -1,0 +1,131 @@
+#ifndef __BSTGW_ETH_BUF_H
+#define __BSTGW_ETH_BUF_H
+
+#define CHECKSUM_NONE       	0
+#define CHECKSUM_UNNECESSARY    1
+#define CHECKSUM_COMPLETE   	2
+#define CHECKSUM_PARTIAL    	3
+
+// from dpdk
+#define RTE_PTYPE_L3_IPV4                   0x00000010
+#define RTE_PTYPE_L3_IPV6                   0x00000040
+#define  RTE_ETH_IS_IPV4_HDR(ptype) ((ptype) & RTE_PTYPE_L3_IPV4)
+#define  RTE_ETH_IS_IPV6_HDR(ptype) ((ptype) & RTE_PTYPE_L3_IPV6)
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <sys/queue.h>
+
+#include <platform_config.h>
+#define BSTGW_CACHE_LINE (STACK_ALIGNMENT) // (==64Bytes) note: 32 might be correct for the imx6
+
+// dpdk: rte_mbuf_ptype.h
+#define RTE_PTYPE_L2_MASK                   0x0000000f
+
+#define BSTGW_DEFAULT_BUF_SIZE (2048) // == FEC_ENET_RX_FRSIZE
+#define BSTGW_PRIV_SIZE (sizeof(npf_mbuf_priv_t))
+
+/*
+ * Packet buffer for holding an Ethernet frame (2B aligned data!)
+ * multiple buffers can be chained (todo: add API)
+ */
+struct bstgw_ether_buffer;
+struct bstgw_ether_buffer {
+    LIST_ENTRY(bstgw_ether_buffer) pool_entry;
+    struct bstgw_ether_buffer *next;
+
+    unsigned int ol_flags;
+    uint32_t packet_type;
+
+    unsigned short l2_len; // link layer (ethernet)
+    unsigned short l3_len; // network layer (ip)
+
+	/* TODO: tx checksum offloading */
+	uint8_t ip_summed:2; // TODO: merge into "ol_flags" (offload flags)
+	struct {
+		uint16_t csum_start;
+		uint16_t csum_offset;
+	};
+
+    void *priv_data;
+
+    size_t data_len;
+    size_t data_off;
+
+    size_t buf_cap;
+    uint8_t *buf; // pointer into raw_buf, i.e., sub-array of it (*buf)[]
+
+    size_t aligned;
+    uint8_t raw_buf[];
+};
+typedef struct bstgw_ether_buffer bstgw_ethbuf_t;
+
+
+
+
+// capacity of the buffer
+inline size_t bstgw_ethbuf_buf_capacity(const bstgw_ethbuf_t *);
+
+// data/payload length of the buffer
+inline size_t bstgw_ethbuf_data_len(const bstgw_ethbuf_t *);
+
+// total length of packet buffer chain
+size_t bstgw_ethbuf_total_pkt_len(const bstgw_ethbuf_t *);
+
+inline void * bstgw_ethbuf_priv(const bstgw_ethbuf_t *);
+
+// pointer to buffer head
+inline uint8_t * bstgw_ethbuf_head(const bstgw_ethbuf_t *);
+
+// pointer to data[offset]
+inline uint8_t * bstgw_ethbuf_data_ptr(const bstgw_ethbuf_t *, size_t);
+
+inline void bstgw_ethbuf_align_check(bstgw_ethbuf_t *);
+
+// try to linearize the chain
+int bstgw_ethbuf_linearize(bstgw_ethbuf_t *);
+
+/* bstgw_ethbuf_precut
+ * Remove space from start of data.
+ * Returns pointer to new data start.
+ *
+ * Warning
+ * This function is highly incomplete.
+ * Because of alignment issues, this is just used for replacing ethernet headers atm.
+ * Also be careful when the buffer length drops to because of that function.
+ */
+// cut from start of data
+// returns pointer to new start of data
+inline uint8_t * bstgw_ethbuf_precut(bstgw_ethbuf_t *, size_t);
+
+/* bstgw_ethbuf_prepend
+ * Add new space to start of data.
+ * Returns pointer to new data start.
+ * 
+ * Warning
+ * This function is highly incomplete.
+ * Because of alignment issues, this is just used for replacing ethernet headers atm.
+ */
+inline uint8_t * bstgw_ethbuf_prepend(bstgw_ethbuf_t *, size_t);
+
+// TODO: add to/remove from chain
+
+void bstgw_ethbuf_dump_meta(bstgw_ethbuf_t *);
+void bstgw_ethbuf_dump_data(bstgw_ethbuf_t *);
+
+/* ************************************************************************** */
+
+/* Add #buffer_number buffers to the pool */
+/*int*/ void bstgw_ethpool_increase(void *, size_t buffer_number);
+
+/* Allocate an ethernet buffer from the pool */
+bstgw_ethbuf_t * bstgw_ethpool_buf_alloc(void *);
+
+/* Put ethernet buffer back into the pool */
+void bstgw_ethpool_buf_free(bstgw_ethbuf_t *eb);
+
+/* Destroy a buffer, i.e., remove it from the pool and free its memory */
+void bstgw_ethpool_buf_destroy(bstgw_ethbuf_t *eb);
+
+#endif /* __BSTGW_ETH_BUF_H */

--- a/core/include/drivers/smsc/bstgw_pktq.h
+++ b/core/include/drivers/smsc/bstgw_pktq.h
@@ -41,8 +41,9 @@ static inline bool bstgw_pktq_locked_is_empty(pktqueue_t *pq) {
 }
 
 static inline size_t bstgw_pktq_locked_bulk_add_buff(pktqueue_t *pq, bstgw_ethbuf_t **bs, size_t nbufs) {
-    assert(pq && bs);
-    int space_left = pq->capacity - pq->count;
+	int space_left;
+	assert(pq && bs);
+	space_left = pq->capacity - pq->count;
     int will_add = (nbufs <= space_left) ? nbufs : space_left;
     for(int i = 0; i < will_add; i++) {
         pq->pkt[pq->next_write] = bs[i];

--- a/core/include/drivers/smsc/bstgw_pktq.h
+++ b/core/include/drivers/smsc/bstgw_pktq.h
@@ -41,10 +41,10 @@ static inline bool bstgw_pktq_locked_is_empty(pktqueue_t *pq) {
 }
 
 static inline size_t bstgw_pktq_locked_bulk_add_buff(pktqueue_t *pq, bstgw_ethbuf_t **bs, size_t nbufs) {
-	int space_left;
+	int space_left, will_add;
 	assert(pq && bs);
 	space_left = pq->capacity - pq->count;
-    int will_add = (nbufs <= space_left) ? nbufs : space_left;
+    will_add = ((int)nbufs <= space_left) ? (int)nbufs : space_left;
     for(int i = 0; i < will_add; i++) {
         pq->pkt[pq->next_write] = bs[i];
         pq->next_write++;
@@ -80,9 +80,10 @@ static inline bool bstgw_pktq_locked_drop_bufs(pktqueue_t *pq, size_t num) {
  * during reading.
  */
 static inline size_t bstgw_pktq_locked_contig_bufs(pktqueue_t *pq) {
+    size_t till_end;
     assert(pq);
     if(__predict_false( bstgw_pktq_locked_is_empty(pq) )) return 0;
-    size_t till_end = 1 + ((pq->capacity - 1) - pq->next_read);
+    till_end = 1 + ((pq->capacity - 1) - pq->next_read);
     if (till_end > pq->count) return pq->count;
     return till_end;
 }

--- a/core/include/drivers/smsc/bstgw_pktq.h
+++ b/core/include/drivers/smsc/bstgw_pktq.h
@@ -1,0 +1,89 @@
+#ifndef __BSTGW_PKTQ_H
+#define __BSTGW_PKTQ_H
+
+#include "bstgw_eth_buf.h"
+
+#include "utils.h"
+
+#include <assert.h>
+
+#include <stdatomic.h>
+
+typedef enum {
+    BSTGW_PKTQ_STOPPED = 0, // default on initialization
+    BSTGW_PKTQ_STARTED,
+} pktq_state_t;
+
+typedef struct {
+	unsigned int	    slock;
+//    pktq_state_t        state;
+    atomic_bool         stopped;
+
+    unsigned int        next_read;
+    unsigned int        next_write;
+
+	unsigned int        count;
+    unsigned int        capacity;
+	//bstgw_ethbuf_t *	pkt[];
+    bstgw_ethbuf_t      **pkt;
+} pktqueue_t;
+
+/* NOTE: all APIs named "*_locked_*" require external locking using &pq.slock */
+
+static inline bool bstgw_pktq_locked_is_full(pktqueue_t *pq) {
+    assert(pq);
+    return (pq->count >= pq->capacity);
+}
+
+static inline bool bstgw_pktq_locked_is_empty(pktqueue_t *pq) {
+    assert(pq);
+    return (pq->count == 0);
+}
+
+static inline size_t bstgw_pktq_locked_bulk_add_buff(pktqueue_t *pq, bstgw_ethbuf_t **bs, size_t nbufs) {
+    assert(pq && bs);
+    int space_left = pq->capacity - pq->count;
+    int will_add = (nbufs <= space_left) ? nbufs : space_left;
+    for(int i = 0; i < will_add; i++) {
+        pq->pkt[pq->next_write] = bs[i];
+        pq->next_write++;
+        pq->next_write %= pq->capacity;
+    }
+    pq->count += will_add;
+    return will_add;
+}
+
+static inline bool bstgw_pktq_locked_add_buf(pktqueue_t *pq, bstgw_ethbuf_t *b) {
+    assert(pq && b);
+    if(__predict_false( bstgw_pktq_locked_is_full(pq) )) return false;
+    pq->pkt[pq->next_write] = b;
+    pq->next_write++;
+    pq->next_write %= pq->capacity;
+    pq->count++;
+    return true;
+}
+
+static inline bool bstgw_pktq_locked_drop_bufs(pktqueue_t *pq, size_t num) {
+    assert(pq && (pq->count >= num));
+    //if(__predict_false( pq->count < num )) return false;
+    pq->next_read += num;
+    pq->next_read %= pq->capacity;
+    pq->count -= num;
+    return true;
+}
+
+/* Number of contigous buffers.
+ * Assuming return value is n, that means, that the interval
+ * pkt[next_read], pkt[next-read+(n-1)] can be consumed without a wrap-around.
+ * Note that more packets might be in the queue, but which require a wrap-around
+ * during reading.
+ */
+static inline size_t bstgw_pktq_locked_contig_bufs(pktqueue_t *pq) {
+    assert(pq);
+    if(__predict_false( bstgw_pktq_locked_is_empty(pq) )) return 0;
+    size_t till_end = 1 + ((pq->capacity - 1) - pq->next_read);
+    if (till_end > pq->count) return pq->count;
+    return till_end;
+}
+
+#endif /* __BSTGW_PKTQ_H */

--- a/core/include/drivers/smsc/errno.h
+++ b/core/include/drivers/smsc/errno.h
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _LINUX_ERRNO_H
+#define _LINUX_ERRNO_H
+
+#define	EPERM		 1	/* Operation not permitted */
+#define	ENOENT		 2	/* No such file or directory */
+#define	ESRCH		 3	/* No such process */
+#define	EINTR		 4	/* Interrupted system call */
+#define	EIO		 5	/* I/O error */
+#define	ENXIO		 6	/* No such device or address */
+#define	E2BIG		 7	/* Argument list too long */
+#define	ENOEXEC		 8	/* Exec format error */
+#define	EBADF		 9	/* Bad file number */
+#define	ECHILD		10	/* No child processes */
+#define	EAGAIN		11	/* Try again */
+#define	ENOMEM		12	/* Out of memory */
+#define	EACCES		13	/* Permission denied */
+#define	EFAULT		14	/* Bad address */
+#define	ENOTBLK		15	/* Block device required */
+#define	EBUSY		16	/* Device or resource busy */
+#define	EEXIST		17	/* File exists */
+#define	EXDEV		18	/* Cross-device link */
+#define	ENODEV		19	/* No such device */
+#define	ENOTDIR		20	/* Not a directory */
+#define	EISDIR		21	/* Is a directory */
+#define	EINVAL		22	/* Invalid argument */
+#define	ENFILE		23	/* File table overflow */
+#define	EMFILE		24	/* Too many open files */
+#define	ENOTTY		25	/* Not a typewriter */
+#define	ETXTBSY		26	/* Text file busy */
+#define	EFBIG		27	/* File too large */
+#define	ENOSPC		28	/* No space left on device */
+#define	ESPIPE		29	/* Illegal seek */
+#define	EROFS		30	/* Read-only file system */
+#define	EMLINK		31	/* Too many links */
+#define	EPIPE		32	/* Broken pipe */
+#define	EDOM		33	/* Math argument out of domain of func */
+#define	ERANGE		34	/* Math result not representable */
+
+
+#define	EDEADLK		35	/* Resource deadlock would occur */
+#define	ENAMETOOLONG	36	/* File name too long */
+#define	ENOLCK		37	/* No record locks available */
+
+/*
+ * This error code is special: arch syscall entry code will return
+ * -ENOSYS if users try to call a syscall that doesn't exist.  To keep
+ * failures of syscalls that really do exist distinguishable from
+ * failures due to attempts to use a nonexistent syscall, syscall
+ * implementations should refrain from returning -ENOSYS.
+ */
+#define	ENOSYS		38	/* Invalid system call number */
+
+#define	ENOTEMPTY	39	/* Directory not empty */
+#define	ELOOP		40	/* Too many symbolic links encountered */
+#define	EWOULDBLOCK	EAGAIN	/* Operation would block */
+#define	ENOMSG		42	/* No message of desired type */
+#define	EIDRM		43	/* Identifier removed */
+#define	ECHRNG		44	/* Channel number out of range */
+#define	EL2NSYNC	45	/* Level 2 not synchronized */
+#define	EL3HLT		46	/* Level 3 halted */
+#define	EL3RST		47	/* Level 3 reset */
+#define	ELNRNG		48	/* Link number out of range */
+#define	EUNATCH		49	/* Protocol driver not attached */
+#define	ENOCSI		50	/* No CSI structure available */
+#define	EL2HLT		51	/* Level 2 halted */
+#define	EBADE		52	/* Invalid exchange */
+#define	EBADR		53	/* Invalid request descriptor */
+#define	EXFULL		54	/* Exchange full */
+#define	ENOANO		55	/* No anode */
+#define	EBADRQC		56	/* Invalid request code */
+#define	EBADSLT		57	/* Invalid slot */
+
+#define	EDEADLOCK	EDEADLK
+
+#define	EBFONT		59	/* Bad font file format */
+#define	ENOSTR		60	/* Device not a stream */
+#define	ENODATA		61	/* No data available */
+#define	ETIME		62	/* Timer expired */
+#define	ENOSR		63	/* Out of streams resources */
+#define	ENONET		64	/* Machine is not on the network */
+#define	ENOPKG		65	/* Package not installed */
+#define	EREMOTE		66	/* Object is remote */
+#define	ENOLINK		67	/* Link has been severed */
+#define	EADV		68	/* Advertise error */
+#define	ESRMNT		69	/* Srmount error */
+#define	ECOMM		70	/* Communication error on send */
+#define	EPROTO		71	/* Protocol error */
+#define	EMULTIHOP	72	/* Multihop attempted */
+#define	EDOTDOT		73	/* RFS specific error */
+#define	EBADMSG		74	/* Not a data message */
+#define	EOVERFLOW	75	/* Value too large for defined data type */
+#define	ENOTUNIQ	76	/* Name not unique on network */
+#define	EBADFD		77	/* File descriptor in bad state */
+#define	EREMCHG		78	/* Remote address changed */
+#define	ELIBACC		79	/* Can not access a needed shared library */
+#define	ELIBBAD		80	/* Accessing a corrupted shared library */
+#define	ELIBSCN		81	/* .lib section in a.out corrupted */
+#define	ELIBMAX		82	/* Attempting to link in too many shared libraries */
+#define	ELIBEXEC	83	/* Cannot exec a shared library directly */
+#define	EILSEQ		84	/* Illegal byte sequence */
+#define	ERESTART	85	/* Interrupted system call should be restarted */
+#define	ESTRPIPE	86	/* Streams pipe error */
+#define	EUSERS		87	/* Too many users */
+#define	ENOTSOCK	88	/* Socket operation on non-socket */
+#define	EDESTADDRREQ	89	/* Destination address required */
+#define	EMSGSIZE	90	/* Message too long */
+#define	EPROTOTYPE	91	/* Protocol wrong type for socket */
+#define	ENOPROTOOPT	92	/* Protocol not available */
+#define	EPROTONOSUPPORT	93	/* Protocol not supported */
+#define	ESOCKTNOSUPPORT	94	/* Socket type not supported */
+#define	EOPNOTSUPP	95	/* Operation not supported on transport endpoint */
+#define	EPFNOSUPPORT	96	/* Protocol family not supported */
+#define	EAFNOSUPPORT	97	/* Address family not supported by protocol */
+#define	EADDRINUSE	98	/* Address already in use */
+#define	EADDRNOTAVAIL	99	/* Cannot assign requested address */
+#define	ENETDOWN	100	/* Network is down */
+#define	ENETUNREACH	101	/* Network is unreachable */
+#define	ENETRESET	102	/* Network dropped connection because of reset */
+#define	ECONNABORTED	103	/* Software caused connection abort */
+#define	ECONNRESET	104	/* Connection reset by peer */
+#define	ENOBUFS		105	/* No buffer space available */
+#define	EISCONN		106	/* Transport endpoint is already connected */
+#define	ENOTCONN	107	/* Transport endpoint is not connected */
+#define	ESHUTDOWN	108	/* Cannot send after transport endpoint shutdown */
+#define	ETOOMANYREFS	109	/* Too many references: cannot splice */
+#define	ETIMEDOUT	110	/* Connection timed out */
+#define	ECONNREFUSED	111	/* Connection refused */
+#define	EHOSTDOWN	112	/* Host is down */
+#define	EHOSTUNREACH	113	/* No route to host */
+#define	EALREADY	114	/* Operation already in progress */
+#define	EINPROGRESS	115	/* Operation now in progress */
+#define	ESTALE		116	/* Stale file handle */
+#define	EUCLEAN		117	/* Structure needs cleaning */
+#define	ENOTNAM		118	/* Not a XENIX named type file */
+#define	ENAVAIL		119	/* No XENIX semaphores available */
+#define	EISNAM		120	/* Is a named type file */
+#define	EREMOTEIO	121	/* Remote I/O error */
+#define	EDQUOT		122	/* Quota exceeded */
+
+#define	ENOMEDIUM	123	/* No medium found */
+#define	EMEDIUMTYPE	124	/* Wrong medium type */
+#define	ECANCELED	125	/* Operation Canceled */
+#define	ENOKEY		126	/* Required key not available */
+#define	EKEYEXPIRED	127	/* Key has expired */
+#define	EKEYREVOKED	128	/* Key has been revoked */
+#define	EKEYREJECTED	129	/* Key was rejected by service */
+
+/* for robust mutexes */
+#define	EOWNERDEAD	130	/* Owner died */
+#define	ENOTRECOVERABLE	131	/* State not recoverable */
+
+#define ERFKILL		132	/* Operation not possible due to RF-kill */
+/*
+ * These should never be seen by user programs.  To return one of ERESTART*
+ * codes, signal_pending() MUST be set.  Note that ptrace can observe these
+ * at syscall exit tracing, but they will never be left for the debugged user
+ * process to see.
+ */
+#define ERESTARTSYS	512
+#define ERESTARTNOINTR	513
+#define ERESTARTNOHAND	514	/* restart if no handler.. */
+#define ENOIOCTLCMD	515	/* No ioctl command */
+#define ERESTART_RESTARTBLOCK 516 /* restart by calling sys_restart_syscall */
+#define EPROBE_DEFER	517	/* Driver requests probe retry */
+#define EOPENSTALE	518	/* open found a stale dentry */
+#define ENOPARAM	519	/* Parameter not supported */
+
+/* Defined for the NFSv3 protocol */
+#define EBADHANDLE	521	/* Illegal NFS file handle */
+#define ENOTSYNC	522	/* Update synchronization mismatch */
+#define EBADCOOKIE	523	/* Cookie is stale */
+#define ENOTSUPP	524	/* Operation is not supported */
+#define ETOOSMALL	525	/* Buffer or request is too small */
+#define ESERVERFAULT	526	/* An untranslatable error occurred */
+#define EBADTYPE	527	/* Type not supported by server */
+#define EJUKEBOX	528	/* Request initiated, but will not complete before timeout */
+#define EIOCBQUEUED	529	/* iocb queued, will get completion event */
+#define ERECALLCONFLICT	530	/* conflict with recalled state */
+#define ENOGRACE	531	/* NFS file lock reclaim refused */
+
+#endif

--- a/core/include/drivers/smsc/mii.h
+++ b/core/include/drivers/smsc/mii.h
@@ -1,0 +1,152 @@
+/*
+ * mii.h
+ *
+ *  Created on: Nov 15, 2022
+ *      Author: rami
+ */
+
+#ifndef MII_H_
+#define MII_H_
+
+/* Generic MII registers. */
+#define MII_BMCR		0x00	/* Basic mode control register */
+#define MII_BMSR		0x01	/* Basic mode status register  */
+#define MII_PHYSID1		0x02	/* PHYS ID 1                   */
+#define MII_PHYSID2		0x03	/* PHYS ID 2                   */
+#define MII_ADVERTISE		0x04	/* Advertisement control reg   */
+#define MII_LPA			0x05	/* Link partner ability reg    */
+#define MII_EXPANSION		0x06	/* Expansion register          */
+#define MII_CTRL1000		0x09	/* 1000BASE-T control          */
+#define MII_STAT1000		0x0a	/* 1000BASE-T status           */
+#define	MII_MMD_CTRL		0x0d	/* MMD Access Control Register */
+#define	MII_MMD_DATA		0x0e	/* MMD Access Data Register */
+#define MII_ESTATUS		0x0f	/* Extended Status             */
+#define MII_DCOUNTER		0x12	/* Disconnect counter          */
+#define MII_FCSCOUNTER		0x13	/* False carrier counter       */
+#define MII_NWAYTEST		0x14	/* N-way auto-neg test reg     */
+#define MII_RERRCOUNTER		0x15	/* Receive error counter       */
+#define MII_SREVISION		0x16	/* Silicon revision            */
+#define MII_RESV1		0x17	/* Reserved...                 */
+#define MII_LBRERROR		0x18	/* Lpback, rx, bypass error    */
+#define MII_PHYADDR		0x19	/* PHY address                 */
+#define MII_RESV2		0x1a	/* Reserved...                 */
+#define MII_TPISTATUS		0x1b	/* TPI status for 10mbps       */
+#define MII_NCONFIG		0x1c	/* Network interface config    */
+
+/* Basic mode control register. */
+#define BMCR_RESV		0x003f	/* Unused...                   */
+#define BMCR_SPEED1000		0x0040	/* MSB of Speed (1000)         */
+#define BMCR_CTST		0x0080	/* Collision test              */
+#define BMCR_FULLDPLX		0x0100	/* Full duplex                 */
+#define BMCR_ANRESTART		0x0200	/* Auto negotiation restart    */
+#define BMCR_ISOLATE		0x0400	/* Isolate data paths from MII */
+#define BMCR_PDOWN		0x0800	/* Enable low power state      */
+#define BMCR_ANENABLE		0x1000	/* Enable auto negotiation     */
+#define BMCR_SPEED100		0x2000	/* Select 100Mbps              */
+#define BMCR_LOOPBACK		0x4000	/* TXD loopback bits           */
+#define BMCR_RESET		0x8000	/* Reset to default state      */
+
+/* Basic mode status register. */
+#define BMSR_ERCAP		0x0001	/* Ext-reg capability          */
+#define BMSR_JCD		0x0002	/* Jabber detected             */
+#define BMSR_LSTATUS		0x0004	/* Link status                 */
+#define BMSR_ANEGCAPABLE	0x0008	/* Able to do auto-negotiation */
+#define BMSR_RFAULT		0x0010	/* Remote fault detected       */
+#define BMSR_ANEGCOMPLETE	0x0020	/* Auto-negotiation complete   */
+#define BMSR_RESV		0x00c0	/* Unused...                   */
+#define BMSR_ESTATEN		0x0100	/* Extended Status in R15      */
+#define BMSR_100HALF2		0x0200	/* Can do 100BASE-T2 HDX       */
+#define BMSR_100FULL2		0x0400	/* Can do 100BASE-T2 FDX       */
+#define BMSR_10HALF		0x0800	/* Can do 10mbps, half-duplex  */
+#define BMSR_10FULL		0x1000	/* Can do 10mbps, full-duplex  */
+#define BMSR_100HALF		0x2000	/* Can do 100mbps, half-duplex */
+#define BMSR_100FULL		0x4000	/* Can do 100mbps, full-duplex */
+#define BMSR_100BASE4		0x8000	/* Can do 100mbps, 4k packets  */
+
+/* Advertisement control register. */
+#define ADVERTISE_SLCT		0x001f	/* Selector bits               */
+#define ADVERTISE_CSMA		0x0001	/* Only selector supported     */
+#define ADVERTISE_10HALF	0x0020	/* Try for 10mbps half-duplex  */
+#define ADVERTISE_1000XFULL	0x0020	/* Try for 1000BASE-X full-duplex */
+#define ADVERTISE_10FULL	0x0040	/* Try for 10mbps full-duplex  */
+#define ADVERTISE_1000XHALF	0x0040	/* Try for 1000BASE-X half-duplex */
+#define ADVERTISE_100HALF	0x0080	/* Try for 100mbps half-duplex */
+#define ADVERTISE_1000XPAUSE	0x0080	/* Try for 1000BASE-X pause    */
+#define ADVERTISE_100FULL	0x0100	/* Try for 100mbps full-duplex */
+#define ADVERTISE_1000XPSE_ASYM	0x0100	/* Try for 1000BASE-X asym pause */
+#define ADVERTISE_100BASE4	0x0200	/* Try for 100mbps 4k packets  */
+#define ADVERTISE_PAUSE_CAP	0x0400	/* Try for pause               */
+#define ADVERTISE_PAUSE_ASYM	0x0800	/* Try for asymetric pause     */
+#define ADVERTISE_RESV		0x1000	/* Unused...                   */
+#define ADVERTISE_RFAULT	0x2000	/* Say we can detect faults    */
+#define ADVERTISE_LPACK		0x4000	/* Ack link partners response  */
+#define ADVERTISE_NPAGE		0x8000	/* Next page bit               */
+
+#define ADVERTISE_FULL		(ADVERTISE_100FULL | ADVERTISE_10FULL | \
+				  ADVERTISE_CSMA)
+#define ADVERTISE_ALL		(ADVERTISE_10HALF | ADVERTISE_10FULL | \
+				  ADVERTISE_100HALF | ADVERTISE_100FULL)
+
+/* Link partner ability register. */
+#define LPA_SLCT		0x001f	/* Same as advertise selector  */
+#define LPA_10HALF		0x0020	/* Can do 10mbps half-duplex   */
+#define LPA_1000XFULL		0x0020	/* Can do 1000BASE-X full-duplex */
+#define LPA_10FULL		0x0040	/* Can do 10mbps full-duplex   */
+#define LPA_1000XHALF		0x0040	/* Can do 1000BASE-X half-duplex */
+#define LPA_100HALF		0x0080	/* Can do 100mbps half-duplex  */
+#define LPA_1000XPAUSE		0x0080	/* Can do 1000BASE-X pause     */
+#define LPA_100FULL		0x0100	/* Can do 100mbps full-duplex  */
+#define LPA_1000XPAUSE_ASYM	0x0100	/* Can do 1000BASE-X pause asym*/
+#define LPA_100BASE4		0x0200	/* Can do 100mbps 4k packets   */
+#define LPA_PAUSE_CAP		0x0400	/* Can pause                   */
+#define LPA_PAUSE_ASYM		0x0800	/* Can pause asymetrically     */
+#define LPA_RESV		0x1000	/* Unused...                   */
+#define LPA_RFAULT		0x2000	/* Link partner faulted        */
+#define LPA_LPACK		0x4000	/* Link partner acked us       */
+#define LPA_NPAGE		0x8000	/* Next page bit               */
+
+#define LPA_DUPLEX		(LPA_10FULL | LPA_100FULL)
+#define LPA_100			(LPA_100FULL | LPA_100HALF | LPA_100BASE4)
+
+/* Expansion register for auto-negotiation. */
+#define EXPANSION_NWAY		0x0001	/* Can do N-way auto-nego      */
+#define EXPANSION_LCWP		0x0002	/* Got new RX page code word   */
+#define EXPANSION_ENABLENPAGE	0x0004	/* This enables npage words    */
+#define EXPANSION_NPCAPABLE	0x0008	/* Link partner supports npage */
+#define EXPANSION_MFAULTS	0x0010	/* Multiple faults detected    */
+#define EXPANSION_RESV		0xffe0	/* Unused...                   */
+
+#define ESTATUS_1000_TFULL	0x2000	/* Can do 1000BT Full          */
+#define ESTATUS_1000_THALF	0x1000	/* Can do 1000BT Half          */
+
+/* N-way test register. */
+#define NWAYTEST_RESV1		0x00ff	/* Unused...                   */
+#define NWAYTEST_LOOPBACK	0x0100	/* Enable loopback for N-way   */
+#define NWAYTEST_RESV2		0xfe00	/* Unused...                   */
+
+/* 1000BASE-T Control register */
+#define ADVERTISE_1000FULL	0x0200  /* Advertise 1000BASE-T full duplex */
+#define ADVERTISE_1000HALF	0x0100  /* Advertise 1000BASE-T half duplex */
+#define CTL1000_AS_MASTER	0x0800
+#define CTL1000_ENABLE_MASTER	0x1000
+
+/* 1000BASE-T Status register */
+#define LPA_1000LOCALRXOK	0x2000	/* Link partner local receiver status */
+#define LPA_1000REMRXOK		0x1000	/* Link partner remote receiver status */
+#define LPA_1000FULL		0x0800	/* Link partner 1000BASE-T full duplex */
+#define LPA_1000HALF		0x0400	/* Link partner 1000BASE-T half duplex */
+
+/* Flow control flags */
+#define FLOW_CTRL_TX		0x01
+#define FLOW_CTRL_RX		0x02
+
+/* MMD Access Control register fields */
+#define MII_MMD_CTRL_DEVAD_MASK	0x1f	/* Mask MMD DEVAD*/
+#define MII_MMD_CTRL_ADDR	0x0000	/* Address */
+#define MII_MMD_CTRL_NOINCR	0x4000	/* no post increment */
+#define MII_MMD_CTRL_INCR_RDWT	0x8000	/* post increment on reads & writes */
+#define MII_MMD_CTRL_INCR_ON_WT	0xC000	/* post increment on writes only */
+
+
+
+#endif /* MII_H_ */

--- a/core/include/drivers/smsc/napi.h
+++ b/core/include/drivers/smsc/napi.h
@@ -1,0 +1,142 @@
+#ifndef BSTGW_NAPI_H
+#define BSTGW_NAPI_H
+
+#include <kernel/spinlock.h>
+#include <kernel/mutex.h>
+
+//#include <stdatomic.h> // WARNING  / TODO: collides with NPF/thmap's memory_order_* macros!
+
+#include <sys/queue.h>
+
+#include <tee_api_types.h>
+
+struct ifnet; //#include <trust_router.h>
+struct bstgw_ether_buffer;
+
+TEE_Result napi_init(void);
+
+struct napi_struct;
+SLIST_HEAD(napi_queue, napi_struct);
+#define NAPI_QUEUE_INITIALIZER { .slh_first = NULL }
+
+struct napi_dev_list {
+	unsigned int nq_slock;
+	struct napi_queue nq;
+};
+extern struct napi_dev_list napi_dlst;
+
+enum gro_result {
+	GRO_MERGED,
+	GRO_MERGED_FREE,
+	GRO_HELD,
+	GRO_NORMAL,
+	GRO_DROP,
+	GRO_CONSUMED,
+};
+typedef enum gro_result gro_result_t;
+
+
+struct sk_buff;
+
+gro_result_t napi_gro_receive(struct napi_struct *napi, struct sk_buff *skb);
+
+struct napi_struct {
+	/* netif_napi_add */
+    int (*poll)(struct napi_struct *, int);
+	int weight;
+	struct ifnet *net_dev;
+	unsigned int idx;
+
+	//gro_result_t (*worker_func)(void *, struct sk_buff *);
+    //void *worker_data;
+
+	/* napi_instance_setup */
+	unsigned long state;
+	unsigned int slock;
+
+	bool is_waiting; // protected by wait_mtx
+    struct mutex *wait_mtx;
+	bool do_notify; // protected by slock
+    struct condvar *wait_cv;
+
+    SLIST_ENTRY(napi_struct) link;
+};
+
+// Warning: different from Linux's NAPI state semantics
+enum {
+	NAPI_STATE_SCHED,	/* Poll worker is running/will run (as soon as the
+						   worker thread becomes active) */
+	NAPI_STATE_MISSED,	/* Pending poll re-schedule */
+	NAPI_STATE_DISABLE,	/* Poll currently (getting) disabled */
+
+	NAPI_STATE_W_ACTIVE, /* bstgw: worker is active, i.e., a NW thread is
+							driving the worker_run() function */
+};
+
+void napi_instance_setup(struct napi_struct *n, struct condvar *wait_cv, struct mutex *wait_mtx);
+
+/**
+ *	netif_napi_add - initialize a NAPI context
+ *	@dev:  network device
+ *	@napi: NAPI context
+ *	@poll: polling function
+ *	@weight: default weight
+ *
+ * netif_napi_add() must be used to initialize a NAPI context prior to calling
+ * *any* of the other NAPI-related functions.
+ */
+// todo: struct net_device?
+//void netif_napi_add(struct net_device *dev, struct napi_struct *napi,
+//		    int (*poll)(struct napi_struct *, int), int weight);
+void netif_napi_add(struct ifnet *dev, struct napi_struct *napi,
+		    int (*poll)(struct napi_struct *, int), int weight);
+
+/**
+ *  netif_napi_del - remove a NAPI context
+ *  @napi: NAPI context
+ *
+ *  netif_napi_del() removes a NAPI context from the network device NAPI list
+ */
+void netif_napi_del(struct napi_struct *napi);
+
+void napi_disable(struct napi_struct *n);
+void napi_enable(struct napi_struct *n);
+
+bool napi_schedule_prep_locked(struct napi_struct *n);
+void __napi_schedule_locked(struct napi_struct *n);
+
+/**
+ *	napi_schedule - schedule NAPI poll
+ *	@n: NAPI context
+ *
+ * Schedule NAPI poll routine to be called if it is not already
+ * running.
+ */
+static inline void napi_schedule(struct napi_struct *n)
+{
+	uint32_t exceptions = cpu_spin_lock_xsave(&n->slock);
+	if (napi_schedule_prep_locked(n))
+		__napi_schedule_locked(n);
+	cpu_spin_unlock_xrestore(&n->slock, exceptions);
+}
+
+bool napi_complete_done(struct napi_struct *n, int work_done);
+/**
+ *	napi_complete - NAPI processing complete
+ *	@n: NAPI context
+ *
+ * Mark NAPI processing as complete.
+ * Consider using napi_complete_done() instead.
+ * Return false if device should avoid rearming interrupts.
+ */
+static inline bool napi_complete(struct napi_struct *n)
+{
+	return napi_complete_done(n, 0);
+}
+
+/* Generic rx_handler for pushing packets from a NIC device to the
+ * trusted router */
+int bstgw_generic_rx_handler(struct ifnet *net_dev,
+    struct bstgw_ether_buffer **pkts /* *pkts[] */, unsigned int pktcount);
+
+#endif /* BSTGW_NAPI_H */

--- a/core/include/drivers/smsc/npf_router.h
+++ b/core/include/drivers/smsc/npf_router.h
@@ -15,8 +15,23 @@
 #ifndef _NPF_ROUTER_H_
 #define _NPF_ROUTER_H_
 
+typedef struct {
+	unsigned		if_idx;
+	unsigned		addr_len;
+//	npf_addr_t		next_hop;
+	unsigned		if_addr_idx;   // IP to use for ARP requests (0:default)
+} route_info_t;
+
+typedef struct {
+	unsigned		flags;
+	unsigned		ether_type;
+	route_info_t	route;
+	unsigned 		out_if_idx;
+} npf_mbuf_priv_t;
 
 typedef struct ifnet {
+
+
 //	LIST_ENTRY(ifnet)	entry;
 //	unsigned int		ifnet_idx; // for router ifnet_map
 //

--- a/core/include/drivers/smsc/npf_router.h
+++ b/core/include/drivers/smsc/npf_router.h
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2022 Fabian Schwarz (CISPA Helmholtz Center for Information Security)
+ * All rights reserved.
+ *
+ * Use is subject to the license terms, as specified in the project LICENSE file.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * Copyright (c) 2020 Mindaugas Rasiukevicius <rmind at noxt eu>
+ * All rights reserved.
+ *
+ * Use is subject to license terms, as specified in the NPF_LICENSE file.
+ */
+
+#ifndef _NPF_ROUTER_H_
+#define _NPF_ROUTER_H_
+
+
+typedef struct ifnet {
+//	LIST_ENTRY(ifnet)	entry;
+//	unsigned int		ifnet_idx; // for router ifnet_map
+//
+//	/* Device Part */
+//	struct rte_ether_addr	hwaddr; // TODO: add and copy @ VNIC/FEC driver init/probe
+//	void * 			priv_data; // like Linux's net_device priv
+//
+//	/* Somewhere in the middle ... (todo: refactor) */
+//	bstgw_trust_t	trust_status;
+//
+//#define BSTGW_MAX_NETIF_NAPI 	2
+//	struct napi_struct *napis[BSTGW_MAX_NETIF_NAPI];
+//	unsigned int 	napi_count;
+//	// pass down to device
+//	xmit_handler_t	*xmit_handler;
+//	// pass up to router
+//	rx_handler_t 	*rx_handler;
+//
+//	// notify about new egress packets
+//	notify_handler_t *egress_ntfy_handler;
+//
+//	char			name[IF_NAMESIZE];
+//
+////	void *			rx_handler_data; // cf. last rx_handler() arg
+//#define BSTGW_MAX_NETIF_WORKER 	BSTGW_MAX_NETIF_NAPI
+//	struct worker *		workers[BSTGW_MAX_NETIF_WORKER];
+//	unsigned int		worker_count;
+//
+//	/* Router/Netif Part */
+//#define BSTGW_MAX_NETIF_IPS 	2
+//	npf_addr_t      if_ips[BSTGW_MAX_NETIF_IPS]; // 0->default; rest: additional
+//	unsigned int	ips_cnt; // number of defined if_ips (should be >=1)
+//
+//	void *			arg;//todo (I think this one will hold the NPF ifnet ID!)
+//	thmap_t *		arp_cache;
+//	uint64_t 		features; // TODO: new
+//	pktqueue_t *	egress_queue;
+} ifnet_t;
+
+#if 0
+
+#include <sys/queue.h>
+#include <inttypes.h>
+
+#include <dpdk/rte_ether.h>
+#include <thmap.h>
+
+//#include <net/if.h>
+#include <net/npf.h>
+#include <npf_firewall/npfkern.h>
+
+// op-tee
+#include <kernel/spinlock.h>
+#include <tee_api_types.h>
+
+#include <bstgw/worker_storage.h>
+#include <bstgw/worker_binding.h>
+
+#include <notifier.h>
+#include <napi.h> // struct napi_struct;
+
+#include "bstgw_eth_buf.h"
+#include "bstgw_pktq.h"
+
+/* Activates check that VNIC does not perform source IP spoofing.
+ * Concrete:  compares VNIC srcIPs against those of the external
+ *            trusted router interface and drops the packet if it
+ *            does not match any
+ *
+ * FIXME:  optimize performance of the implementation
+ *
+ * Note:  can be implemented more efficiently using a firewall rule;
+ *        the firewall can use connection tracking to avoid checks
+ *        on already ESTABLISHED connections to reduce the overhead;
+ *
+ *        a firewall rule can also whitelist additional source IPs
+ *        if that is desired in a given use-case */
+//#define BSTGW_NON_NPF_ANTI_IP_SPOOFING
+
+struct ifnet;
+struct worker;
+
+typedef int rx_handler_t(struct ifnet *, bstgw_ethbuf_t **pkts, unsigned int pktcount);
+typedef int xmit_handler_t(struct ifnet *, bstgw_ethbuf_t **pkts, unsigned int pktcount);
+typedef int notify_handler_t(struct ifnet *);
+
+typedef struct route_table route_table_t;
+
+#define IF_NAMESIZE 		(16)
+
+/*
+ * NPF router structures.
+ */
+
+typedef struct {
+	unsigned		if_idx;
+	unsigned		addr_len;
+	npf_addr_t		next_hop;
+	unsigned		if_addr_idx;   // IP to use for ARP requests (0:default)
+} route_info_t;
+
+#define	MBUF_NPF_NEED_L2	0x01
+
+typedef enum { BSTGW_IF_NONSEC, BSTGW_IF_EXTERNAL } bstgw_trust_t;
+
+typedef struct {
+	unsigned		flags;
+	unsigned		ether_type;
+	route_info_t	route;
+	unsigned 		out_if_idx;
+} npf_mbuf_priv_t;
+
+/* TODO: from netdev_features.h */
+enum {
+	NETIF_F_SG_BIT,			/* Scatter/gather IO. */
+	NETIF_F_IP_CSUM_BIT,		/* Can checksum TCP/UDP over IPv4. */
+	NETIF_F_HW_VLAN_CTAG_RX_BIT,	/* Receive VLAN CTAG HW acceleration */
+	NETIF_F_RXCSUM_BIT,		/* Receive checksumming offload */
+};
+
+#define __NETIF_F_BIT(bit)	((netdev_features_t)1 << (bit))
+#define __NETIF_F(name)		__NETIF_F_BIT(NETIF_F_##name##_BIT)
+
+#define NETIF_F_HW_VLAN_CTAG_RX	__NETIF_F(HW_VLAN_CTAG_RX)
+#define NETIF_F_IP_CSUM			__NETIF_F(IP_CSUM)
+#define NETIF_F_RXCSUM			__NETIF_F(RXCSUM)
+#define NETIF_F_SG				__NETIF_F(SG)
+/* */
+
+typedef struct ifnet {
+	LIST_ENTRY(ifnet)	entry;
+	unsigned int		ifnet_idx; // for router ifnet_map
+
+	/* Device Part */
+	struct rte_ether_addr	hwaddr; // TODO: add and copy @ VNIC/FEC driver init/probe
+	void * 			priv_data; // like Linux's net_device priv
+
+	/* Somewhere in the middle ... (todo: refactor) */
+	bstgw_trust_t	trust_status;
+
+#define BSTGW_MAX_NETIF_NAPI 	2
+	struct napi_struct *napis[BSTGW_MAX_NETIF_NAPI];
+	unsigned int 	napi_count;
+	// pass down to device
+	xmit_handler_t	*xmit_handler;
+	// pass up to router
+	rx_handler_t 	*rx_handler;
+	
+	// notify about new egress packets
+	notify_handler_t *egress_ntfy_handler;
+
+	char			name[IF_NAMESIZE];
+
+//	void *			rx_handler_data; // cf. last rx_handler() arg
+#define BSTGW_MAX_NETIF_WORKER 	BSTGW_MAX_NETIF_NAPI
+	struct worker *		workers[BSTGW_MAX_NETIF_WORKER];
+	unsigned int		worker_count;
+
+	/* Router/Netif Part */
+#define BSTGW_MAX_NETIF_IPS 	2
+	npf_addr_t      if_ips[BSTGW_MAX_NETIF_IPS]; // 0->default; rest: additional
+	unsigned int	ips_cnt; // number of defined if_ips (should be >=1)
+
+	void *			arg;//todo (I think this one will hold the NPF ifnet ID!)
+	thmap_t *		arp_cache;
+	uint64_t 		features; // TODO: new
+	pktqueue_t *	egress_queue;
+} ifnet_t;
+
+static inline void *netdev_priv(const struct ifnet *dev) {
+	assert(dev);
+	return dev->priv_data;
+}
+
+extern struct ifnet_list {
+	unsigned int slock;
+	LIST_HEAD(, ifnet) list;
+} netdev_list;
+
+typedef struct npf_router {
+	npf_t *			npf;
+	//struct rte_mempool *	mbuf_pool;
+	unsigned		pktqueue_size;
+	route_table_t *		rtable;
+
+	struct notifier notfer;
+
+#ifdef BSTGW_NON_NPF_ANTI_IP_SPOOFING
+#define BSTGW_MAX_EXT_NDEVS 2
+	unsigned 		ext_ndevs_count;
+	struct ifnet_t *	ext_ndevs[BSTGW_MAX_EXT_NDEVS];
+#endif
+
+	unsigned		worker_count;
+	struct worker *		worker[];
+} npf_router_t;
+
+typedef enum { BSTGW_WRK_INOUT = 0, BSTGW_WRK_OUT = 1 } worker_type_t;
+
+typedef struct worker {
+	wrk_ls_t worker_npf_data;
+	int worker_id; // unused atm
+
+	npf_t *			npf;
+	npf_router_t *	router;
+
+	worker_bind_t 	bind;
+
+	ifnet_t * 		net_if;
+	unsigned int 	napi_idx;
+} worker_t;
+
+/*
+ * NPF DPDK operations, network interface and configuration loading.
+ */
+
+npf_t *		npf_dpdk_create(int, npf_router_t *);
+
+/* new (TODO) */
+int		ifnet_dev_init(ifnet_t *netdev);
+int		ifnet_dev_register(ifnet_t *netdev);
+
+unsigned int ifnet_napi_count(void);
+unsigned int ifnet_dev_count(void);
+
+unsigned int ifnet_nametoindex(const char *ifname);
+ifnet_t * ifnet_getbyidx(unsigned int idx);
+ifnet_t * ifnet_getbyname(const char *ifname);
+
+void ifnet_flush_arg(void *arg);
+
+nvlist_t *ifnet_get_descr_list(void);
+/*  */
+
+
+int 	ifnet_setup(npf_router_t *router, ifnet_t *);
+
+int		ifnet_ifattach(npf_router_t *, ifnet_t *);
+void		ifnet_ifdetach(npf_router_t *, ifnet_t *);
+//void		ifnet_put(ifnet_t *);
+
+int		load_config(npf_router_t *);
+
+/*
+ * Routing and ARP.
+ */
+
+route_table_t *	route_table_create(void);
+void		route_table_destroy(route_table_t *);
+
+int		route_add(route_table_t *, const void *, unsigned, unsigned,
+		    const route_info_t *);
+int		route_lookup(route_table_t *, const void *, unsigned,
+		    route_info_t *);
+
+int		arp_resolve(worker_t *, const route_info_t *, struct rte_ether_addr *);
+int		arp_input(worker_t *, bstgw_ethbuf_t *);
+
+/*
+ * Worker / processing.
+ */
+
+int worker_get_number(void); // called by NW
+worker_t *bind_to_worker(void); // called by NW
+void detach_nw_from_worker(worker_t *); // called by NW
+
+int worker_run(worker_t *); // called by NW
+
+int     pktq_prepare_enqueue(worker_t *, unsigned, bstgw_ethbuf_t *);
+int		pktq_do_menqueue(worker_t *, unsigned, bstgw_ethbuf_t **, unsigned int);
+int     pktq_enqueue(worker_t *, unsigned , bstgw_ethbuf_t *);
+
+void	router_if_input(worker_t *, bstgw_ethbuf_t **, unsigned int);
+int     router_pktq_tx(ifnet_t *);
+
+uint32_t router_in_burst_size(ifnet_t *, ifnet_t *);
+
+extern npf_router_t *trusted_router;
+
+/*
+ * NPF Worker.
+ */
+wrk_ls_t *bind_to_npfworker(void);
+void npfworker_run(void);
+void detach_nw_from_npfworker(void);
+
+/*
+ * NPF Config.
+ */
+#include <npf_firewall/npf_impl.h>
+
+int bstgw_npfctl_cmd(uint64_t, nvlist_t *, nvlist_t *);
+#endif
+#endif

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -80,7 +80,7 @@ static inline void skb_reserve(struct sk_buff *skb, int len) {
 	assert(skb->eth_buf.data_len == 0);
 	cap = bstgw_ethbuf_buf_capacity(&skb->eth_buf);
 	if(unlikely( (size_t)len <= (cap - skb->eth_buf.data_off) )) {
-		EMSG("reserve len > rest buffer size (len: %d, data_off: %u)", len, skb->eth_buf.data_off);
+		EMSG("reserve len > rest buffer size (len: %d, data_off: %lu)", len, skb->eth_buf.data_off);
 		panic();
 	}
 	// TODO: alignment breaking risk! (adjust FEC driver)

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -23,10 +23,10 @@ struct sk_buff {
 static inline void *skb_put(struct sk_buff *skb, unsigned int len) {
 	const size_t rem_space = skb->eth_buf.buf_cap
 		- (skb->eth_buf.data_off + skb->eth_buf.data_len);
+	const size_t old_len = skb->eth_buf.data_len;
 
 	if(unlikely( rem_space < len )) panic("skb_put not enough free buffer space");
 
-	const size_t old_len = skb->eth_buf.data_len;
 	skb->eth_buf.data_len += len;
 	return bstgw_ethbuf_data_ptr(&skb->eth_buf, old_len);
 }

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -49,10 +49,10 @@ static inline const unsigned char *skb_head(struct sk_buff *skb) {
 
 /* TODO: scatter gather I/O support */
 static inline unsigned char skb_nr_frags(struct sk_buff *skb) {
-	if(likely( !skb->eth_buf.next )) return 0;
-	// count number of chained ethbufs
 	unsigned char n = 0;
 	bstgw_ethbuf_t *b = skb->eth_buf.next;
+	if(likely( !skb->eth_buf.next )) return 0;
+	// count number of chained ethbufs
 	while( b ) { n++; b = b->next; }
 	return n;
 }
@@ -76,9 +76,10 @@ static inline unsigned char skb_nr_frags(struct sk_buff *skb) {
 //		NOTE:  often this fct. is used for the 2B ethernet-IP alginment fix,
 //			   but we already have that in our struct definition atm.
 static inline void skb_reserve(struct sk_buff *skb, int len) {
+	int cap;
 	assert(skb->eth_buf.data_len == 0);
-	int cap = bstgw_ethbuf_buf_capacity(&skb->eth_buf);
-	if(unlikely( len <= (cap - skb->eth_buf.data_off) )) {
+	cap = bstgw_ethbuf_buf_capacity(&skb->eth_buf);
+	if(unlikely( (size_t)len <= (cap - skb->eth_buf.data_off) )) {
 		EMSG("reserve len > rest buffer size (len: %d, data_off: %u)", len, skb->eth_buf.data_off);
 		panic();
 	}

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -11,7 +11,25 @@ struct sk_buff {
 	struct bstgw_ether_buffer eth_buf;
 };
 
-void *skb_put(struct sk_buff *skb, unsigned int len);
+/**
+ *  skb_put - add data to a buffer
+ *  @skb: buffer to use
+ *  @len: amount of data to add
+ *
+ *  This function extends the used data area of the buffer. If this would
+ *  exceed the total buffer size the kernel will panic. A pointer to the
+ *  first byte of the extra data is returned.
+ */
+static inline void *skb_put(struct sk_buff *skb, unsigned int len) {
+	const size_t rem_space = skb->eth_buf.buf_cap
+		- (skb->eth_buf.data_off + skb->eth_buf.data_len);
+
+	if(unlikely( rem_space < len )) panic("skb_put not enough free buffer space");
+
+	const size_t old_len = skb->eth_buf.data_len;
+	skb->eth_buf.data_len += len;
+	return bstgw_ethbuf_data_ptr(&skb->eth_buf, old_len);
+}
 
 static inline void dev_kfree_skb(struct sk_buff *skb) {
 	bstgw_ethpool_buf_free((bstgw_ethbuf_t *)skb);

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -1,0 +1,119 @@
+#ifndef BSTGW_SKBUFF_STUB_H
+#define BSTGW_SKBUFF_STUB_H
+
+#include "utils.h"
+#include <drivers/smsc/npf_router.h>
+
+//#include <newlib/netinet/ip.h>
+
+#include <drivers/smsc/bstgw_eth_buf.h>
+struct sk_buff {
+	struct bstgw_ether_buffer eth_buf;
+};
+
+void *skb_put(struct sk_buff *skb, unsigned int len);
+
+static inline void dev_kfree_skb(struct sk_buff *skb) {
+	bstgw_ethpool_buf_free((bstgw_ethbuf_t *)skb);
+}
+
+// note: actually this is for calling for diff. reasons / from
+// different contexts (e.g., process, irq, unknown)
+static inline void dev_kfree_skb_any(struct sk_buff *skb) {
+	dev_kfree_skb(skb);
+}
+
+// headlen is the linear data length, i.e., our data_len;
+// our skb->len analogue is bstgw_ethbuf_total_pkt_len();
+static inline unsigned int skb_headlen(struct sk_buff *skb) {
+	return skb->eth_buf.data_len;
+}
+
+static inline struct ip *ip_hdr(const struct sk_buff *skb) {
+    return (struct ip *) bstgw_ethbuf_data_ptr(
+        &skb->eth_buf, skb->eth_buf.l2_len
+    );
+}
+
+static inline unsigned char *skb_data(struct sk_buff *skb) {
+	assert(skb);
+	return &skb->eth_buf.buf[skb->eth_buf.data_off];
+
+    // note: caused NULL return when data_len was 0 (directly after allocation)
+	//return bstgw_ethbuf_data_ptr(&skb->eth_buf, 0);
+}
+
+static inline const unsigned char *skb_head(struct sk_buff *skb) {
+	return bstgw_ethbuf_head(&skb->eth_buf);
+}
+
+/* TODO: scatter gather I/O support */
+static inline unsigned char skb_nr_frags(struct sk_buff *skb) {
+	if(likely( !skb->eth_buf.next )) return 0;
+	// count number of chained ethbufs
+	unsigned char n = 0;
+	bstgw_ethbuf_t *b = skb->eth_buf.next;
+	while( b ) { n++; b = b->next; }
+	return n;
+}
+
+// macros to allow r/w access
+#define skb_ip_summed(sb) 	sb->eth_buf.ip_summed
+#define skb_csum_start(sb) 	sb->eth_buf.csum_start
+#define skb_csum_offset(sb) sb->eth_buf.csum_offset
+
+/**
+ *  skb_reserve - adjust headroom
+ *  @skb: buffer to alter
+ *  @len: bytes to move
+ *
+ *  Increase the headroom of an empty &sk_buff by reducing the tail
+ *  room. This is only allowed for an empty buffer.
+ */
+// TODO: we don't have an explicit head/tail-room definition;
+//		 closest would be to move the data_offset while data_len is 0,
+//		 s.t., the data would not start at 0;
+//		NOTE:  often this fct. is used for the 2B ethernet-IP alginment fix,
+//			   but we already have that in our struct definition atm.
+static inline void skb_reserve(struct sk_buff *skb, int len) {
+	assert(skb->eth_buf.data_len == 0);
+	int cap = bstgw_ethbuf_buf_capacity(&skb->eth_buf);
+	if(unlikely( len <= (cap - skb->eth_buf.data_off) )) {
+		EMSG("reserve len > rest buffer size (len: %d, data_off: %u)", len, skb->eth_buf.data_off);
+		panic();
+	}
+	// TODO: alignment breaking risk! (adjust FEC driver)
+	skb->eth_buf.data_off += len;
+}
+
+/*TODO: "Although this function allocates memory it can be called
+ *      from an interrupt."
+ * __netdev_alloc_skb(dev, length, GFP_ATOMIC);
+ */
+struct sk_buff *netdev_alloc_skb(ifnet_t *netdev, unsigned int length);
+
+/**
+ *  skb_pull - remove data from the start of a buffer
+ *  @skb: buffer to use
+ *  @len: amount of data to remove
+ *
+ *  This function removes data from the start of a buffer, returning
+ *  the memory to the headroom. A pointer to the next data in the buffer
+ *  is returned. Once the data has been pulled future pushes will overwrite
+ *  the old data.
+ */
+static inline void *skb_pull_inline(struct sk_buff *skb, unsigned int len) {
+	return bstgw_ethbuf_precut(&skb->eth_buf, len);
+}
+
+static inline void *skb_pull(struct sk_buff *skb, unsigned int len) {
+    return skb_pull_inline(skb, len);
+}
+
+static inline
+void skb_checksum_none_assert(const struct sk_buff *skb __maybe_unused) {
+	// TODO: assert() still not working again
+	assert(skb->eth_buf.ip_summed == CHECKSUM_NONE);
+}
+
+#endif /* BSTGW_SKBUFF_STUB_H */

--- a/core/include/drivers/smsc/skbuff_stub.h
+++ b/core/include/drivers/smsc/skbuff_stub.h
@@ -97,7 +97,7 @@ static inline void skb_reserve(struct sk_buff *skb, int len) {
 	int cap;
 	assert(skb->eth_buf.data_len == 0);
 	cap = bstgw_ethbuf_buf_capacity(&skb->eth_buf);
-	if(unlikely( (size_t)len <= (cap - skb->eth_buf.data_off) )) {
+	if(unlikely( (size_t)len > (cap - skb->eth_buf.data_off) )) {
 		EMSG("reserve len > rest buffer size (len: %d, data_off: %lu)", len, skb->eth_buf.data_off);
 		panic();
 	}

--- a/core/include/drivers/smsc/smsc91x.h
+++ b/core/include/drivers/smsc/smsc91x.h
@@ -30,7 +30,7 @@
 
 #define CARDNAME "smc91x"
 
-#define SMC_DEBUG 0
+#define SMC_DEBUG 4
 
 #define CHIP_9192	3
 #define CHIP_9194	4
@@ -484,9 +484,9 @@
 #define SMC_PUSH_DATA(smsc, p, l)					\
 	do {								\
 		if (SMC_32BIT(smsc)) {				\
-			uintptr_t __ptr = (uintptr_t)(p);				\
+			void *__ptr = (p);				\
 			int __len = (l);				\
-			paddr_t __iomem __ioaddr = ioaddr;		\
+			void __iomem *__ioaddr = ioaddr;		\
 			if (__len >= 2 && (unsigned long)__ptr & 2) {	\
 				__len -= 2;				\
 				SMC_outw(*(u16 *)__ptr, ioaddr,		\
@@ -495,7 +495,7 @@
 			}						\
 			if (SMC_CAN_USE_DATACS && smsc->datacs)		\
 				__ioaddr = smsc->datacs;			\
-			SMC_outsl(__ioaddr, DATA_REG(smsc), (const void *)__ptr, __len>>2); \
+			SMC_outsl(__ioaddr, DATA_REG(smsc), __ptr, __len>>2); \
 			if (__len & 2) {				\
 				__ptr += (__len & ~3);			\
 				SMC_outw(*((u16 *)__ptr), ioaddr,	\
@@ -603,7 +603,6 @@ struct smc_local {
 	struct smc91x_platdata cfg;
 };
 
-
-int smc_hard_start_xmit(struct sk_buff *skb);
+void send_test_pkt(void);
 
 #endif /* SMC91X_H_ */

--- a/core/include/drivers/smsc/smsc91x.h
+++ b/core/include/drivers/smsc/smsc91x.h
@@ -26,6 +26,7 @@
 
 #include <drivers/smsc/bstgw_pktq.h>
 
+#define __iomem
 
 #define CARDNAME "smc91x"
 
@@ -33,14 +34,99 @@
 
 // Base Address Register
 /* BANK 1 */
-#define BASE_REG(lp)	SMC_REG(lp, 0x0002, 1)
+#define BASE_REG(smsc)	SMC_REG(smsc, 0x0002, 1)
+
+
+// Receive Control Register
+/* BANK 0  */
+#define RCR_REG(smsc)		SMC_REG(smsc, 0x0004, 0)
+#define RCR_RX_ABORT	0x0001	// Set if a rx frame was aborted
+#define RCR_PRMS	0x0002	// Enable promiscuous mode
+#define RCR_ALMUL	0x0004	// When set accepts all multicast frames
+#define RCR_RXEN	0x0100	// IFF this is set, we can receive packets
+#define RCR_STRIP_CRC	0x0200	// When set strips CRC from rx packets
+#define RCR_ABORT_ENB	0x0200	// When set will abort rx on collision
+#define RCR_FILT_CAR	0x0400	// When set filters leading 12 bit s of carrier
+#define RCR_SOFTRST	0x8000 	// resets the chip
+
+/* the normal settings for the RCR register : */
+#define RCR_DEFAULT	(RCR_STRIP_CRC | RCR_RXEN)
+#define RCR_CLEAR	0x0	// set it to a base state
+
+
+// Transmit Control Register
+/* BANK 0  */
+#define TCR_REG(smsc) 	SMC_REG(smsc, 0x0000, 0)
+#define TCR_ENABLE	0x0001	// When 1 we can transmit
+#define TCR_LOOP	0x0002	// Controls output pin LBK
+#define TCR_FORCOL	0x0004	// When 1 will force a collision
+#define TCR_PAD_EN	0x0080	// When 1 will pad tx frames < 64 bytes w/0
+#define TCR_NOCRC	0x0100	// When 1 will not append CRC to tx frames
+#define TCR_MON_CSN	0x0400	// When 1 tx monitors carrier
+#define TCR_FDUPLX    	0x0800  // When 1 enables full duplex operation
+#define TCR_STP_SQET	0x1000	// When 1 stops tx if Signal Quality Error
+#define TCR_EPH_LOOP	0x2000	// When 1 enables EPH block loopback
+#define TCR_SWFDUP	0x8000	// When 1 enables Switched Full Duplex mode
+
+#define TCR_CLEAR	0	/* do NOTHING */
+/* the default settings for the TCR register : */
+#define TCR_DEFAULT	(TCR_ENABLE | TCR_PAD_EN)
+
+
+// Control Register
+/* BANK 1 */
+#define CTL_REG(smsc)		SMC_REG(smsc, 0x000C, 1)
+#define CTL_RCV_BAD	0x4000 // When 1 bad CRC packets are received
+#define CTL_AUTO_RELEASE 0x0800 // When 1 tx pages are released automatically
+#define CTL_LE_ENABLE	0x0080 // When 1 enables Link Error interrupt
+#define CTL_CR_ENABLE	0x0040 // When 1 enables Counter Rollover interrupt
+#define CTL_TE_ENABLE	0x0020 // When 1 enables Transmit Error interrupt
+#define CTL_EEPROM_SELECT 0x0004 // Controls EEPROM reload & store
+#define CTL_RELOAD	0x0002 // When set reads EEPROM into registers
+#define CTL_STORE	0x0001 // When set stores registers into EEPROM
+
+
+// Configuration Reg
+/* BANK 1 */
+#define CONFIG_REG(smsc)	SMC_REG(smsc, 0x0000,	1)
+#define CONFIG_EXT_PHY	0x0200	// 1=external MII, 0=internal Phy
+#define CONFIG_GPCNTRL	0x0400	// Inverse value drives pin nCNTRL
+#define CONFIG_NO_WAIT	0x1000	// When 1 no extra wait states on ISA bus
+#define CONFIG_EPH_POWER_EN 0x8000 // When 0 EPH is placed into low power mode.
+
+// Default is powered-up, Internal Phy, Wait States, and pin nCNTRL=low
+#define CONFIG_DEFAULT	(CONFIG_EPH_POWER_EN)
+
+
+// MMU Command Register
+/* BANK 2 */
+#define MMU_CMD_REG(smsc)	SMC_REG(smsc, 0x0000, 2)
+#define MC_BUSY		1	// When 1 the last release has not completed
+#define MC_NOP		(0<<5)	// No Op
+#define MC_ALLOC	(1<<5) 	// OR with number of 256 byte packets
+#define MC_RESET	(2<<5)	// Reset MMU to initial state
+#define MC_REMOVE	(3<<5) 	// Remove the current rx packet
+#define MC_RELEASE  	(4<<5) 	// Remove and release the current rx packet
+#define MC_FREEPKT  	(5<<5) 	// Release packet in PNR register
+#define MC_ENQUEUE	(6<<5)	// Enqueue the packet for transmit
+#define MC_RSTTXFIFO	(7<<5)	// Reset the TX FIFOs
+
+
+/*
+ * This selects whether TX packets are sent one by one to the SMC91x internal
+ * memory and throttled until transmission completes.  This may prevent
+ * RX overruns a litle by keeping much of the memory free for RX packets
+ * but to the expense of reduced TX throughput and increased IRQ overhead.
+ * Note this is not a cure for a too slow data bus or too high IRQ latency.
+ */
+#define THROTTLE_TX_PKTS	0
 
 // Revision Register
 /* BANK 3 */
 /* ( hi: chip id   low: rev # ) */
-#define REV_REG(lp)		SMC_REG(lp, 0x000A, 3)
+#define REV_REG(smsc)		SMC_REG(smsc, 0x000A, 3)
 
-#define SMC_GET_REV(lp)		SMC_inw(ioaddr, REV_REG(lp))
+#define SMC_GET_REV(smsc)		SMC_inw(ioaddr, REV_REG(smsc))
 
 #define SMC_CAN_USE_8BIT	1
 #define SMC_CAN_USE_16BIT	1
@@ -70,12 +156,12 @@
 #define RPC_LED_TX	(0x06)	/* LED = TX packet occurred */
 #define RPC_LED_RX	(0x07)	/* LED = RX packet occurred */
 
-#define SMC_inb(a, r)		io_read8((a) + (r))
-#define SMC_inw(a, r)		io_read16((a) + (r))
-#define SMC_inl(a, r)		io_read32((a) + (r))
-#define SMC_outb(v, a, r)	io_write8((a) + (r), v)
-#define SMC_outw(v, a, r)	io_write16((a) + (r), v)
-#define SMC_outl(v, a, r)	io_write32((a) + (r), v)
+#define SMC_inb(a, r)		io_read8((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_inw(a, r)		io_read16((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_inl(a, r)		io_read32((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_outb(v, a, r)	io_write8((uintptr_t)(a) + (uintptr_t)(r), v)
+#define SMC_outw(v, a, r)	io_write16((uintptr_t)(a) + (uintptr_t)(r), v)
+#define SMC_outl(v, a, r)	io_write32((uintptr_t)(a) + (uintptr_t)(r), v)
 //#define SMC_insw(a, r, p, l)	readsw((a) + (r), p, l)
 //#define SMC_outsw(a, r, p, l)	writesw((a) + (r), p, l)
 //#define SMC_insl(a, r, p, l)	readsl((a) + (r), p, l)
@@ -84,9 +170,9 @@
 
 #define SMC_IO_SHIFT		(smsc->io_shift)
 
-#define SMC_8BIT(p)	((p)->cfg.flags & SMC91X_USE_8BIT)
-#define SMC_16BIT(p)	((p)->cfg.flags & SMC91X_USE_16BIT)
-#define SMC_32BIT(p)	((p)->cfg.flags & SMC91X_USE_32BIT)
+#define SMC_8BIT(smsc)	((smsc)->cfg.flags & SMC91X_USE_8BIT)
+#define SMC_16BIT(smsc)	((smsc)->cfg.flags & SMC91X_USE_16BIT)
+#define SMC_32BIT(smsc)	((smsc)->cfg.flags & SMC91X_USE_32BIT)
 
 /*
  * Hack Alert: Some setups just can't write 8 or 16 bits reliably when not
@@ -97,9 +183,9 @@
  *
  * Enforce it on any 32-bit capable setup for now.
  */
-#define SMC_MUST_ALIGN_WRITE(lp)	SMC_32BIT(lp)
+#define SMC_MUST_ALIGN_WRITE(smsc)	SMC_32BIT(smsc)
 
-#define SMC_GET_BASE(lp)		SMC_inw(ioaddr, BASE_REG(lp))
+#define SMC_GET_BASE(smsc)		SMC_inw(ioaddr, BASE_REG(smsc))
 
 /*
  . Bank Select Register:
@@ -110,17 +196,79 @@
 */
 #define BANK_SELECT		(14 << SMC_IO_SHIFT)
 
-#define SMC_CURRENT_BANK(lp)	SMC_inw(ioaddr, BANK_SELECT)
+#define SMC_CURRENT_BANK(smsc)	SMC_inw(ioaddr, BANK_SELECT)
 
-#define SMC_SELECT_BANK(lp, x)					\
+#define SMC_SELECT_BANK(smsc, x)					\
 	do {								\
-		if (SMC_MUST_ALIGN_WRITE(lp))				\
+		if (SMC_MUST_ALIGN_WRITE(smsc))				\
 			SMC_outl((x)<<16, ioaddr, 12<<SMC_IO_SHIFT);	\
 		else							\
 			SMC_outw(x, ioaddr, BANK_SELECT);		\
 	} while (0)
 
+
+#define SMC_REG(smsc, reg, bank)	(reg<<SMC_IO_SHIFT)
+
+#define SMC_GET_CTL(smsc)		SMC_inw(ioaddr, CTL_REG(smsc))
+
+#define SMC_SET_CTL(smsc, x)		SMC_outw(x, ioaddr, CTL_REG(smsc))
+
+#define SMC_SET_RCR(smsc, x)		SMC_outw(x, ioaddr, RCR_REG(smsc))
+
+#define SMC_SET_TCR(smsc, x)		SMC_outw(x, ioaddr, TCR_REG(smsc))
+
+#define SMC_SET_CONFIG(smsc, x)	SMC_outw(x, ioaddr, CONFIG_REG(smsc))
+
+#define SMC_SET_MMU_CMD(smsc, x)	SMC_outw(x, ioaddr, MMU_CMD_REG(smsc))
+
+// Interrupt Mask Register
+/* BANK 2 */
+#define IM_REG(smsc)		SMC_REG(smsc, 0x000D, 2)
+#define IM_MDINT	0x80 // PHY MI Register 18 Interrupt
+#define IM_ERCV_INT	0x40 // Early Receive Interrupt
+#define IM_EPH_INT	0x20 // Set by Ethernet Protocol Handler section
+#define IM_RX_OVRN_INT	0x10 // Set by Receiver Overruns
+#define IM_ALLOC_INT	0x08 // Set when allocation request is completed
+#define IM_TX_EMPTY_INT	0x04 // Set if the TX FIFO goes empty
+#define IM_TX_INT	0x02 // Transmit Interrupt
+#define IM_RCV_INT	0x01 // Receive Interrupt
+
+
+// Interrupt Status/Acknowledge Register
+/* BANK 2 */
+#define INT_REG(smsc)		SMC_REG(smsc, 0x000C, 2)
+
+#define SMC_SET_INT_MASK(smsc, x)					\
+	do {								\
+		if (SMC_8BIT(smsc))					\
+			SMC_outb(x, ioaddr, IM_REG(smsc));		\
+		else							\
+			SMC_outw((x) << 8, ioaddr, INT_REG(smsc));	\
+	} while (0)
+
+// Individual Address Registers
+/* BANK 1 */
+#define ADDR0_REG(smsc)	SMC_REG(smsc, 0x0004, 1)
+#define ADDR1_REG(smsc)	SMC_REG(smsc, 0x0006, 1)
+#define ADDR2_REG(smsc)	SMC_REG(smsc, 0x0008, 1)
+
+#ifndef SMC_GET_MAC_ADDR
+#define SMC_GET_MAC_ADDR(smsc, addr)					\
+	do {								\
+		unsigned int __v;					\
+		__v = SMC_inw(ioaddr, ADDR0_REG(smsc));			\
+		addr[0] = __v; addr[1] = __v >> 8;			\
+		__v = SMC_inw(ioaddr, ADDR1_REG(smsc));			\
+		addr[2] = __v; addr[3] = __v >> 8;			\
+		__v = SMC_inw(ioaddr, ADDR2_REG(smsc));			\
+		addr[4] = __v; addr[5] = __v >> 8;			\
+	} while (0)
+#endif
+
+
 typedef unsigned int spinlock_t;
+
+#define IF_NAMESIZE 		(16)
 
 /* Maximum number of queues supported */
 #define FEC_ENET_MAX_TX_QS	1
@@ -147,13 +295,10 @@ struct smc_local {
 //	 * packet, I will store the skbuff here, until I get the
 //	 * desired memory.  Then, I'll send it out and free it.
 //	 */
-//	struct sk_buff *pending_tx_skb;
-//#if 0
-//	struct tasklet_struct tx_task;
-//#endif
-//
-//	/* version/revision of the SMC91x chip */
-//	int	version;
+	struct sk_buff *pending_tx_skb;
+
+	/* version/revision of the SMC91x chip */
+	int	version;
 //
 //	/* Contains the current active transmission mode */
 //	int	tcr_cur_mode;
@@ -175,23 +320,25 @@ struct smc_local {
 //	struct net_device *dev;
 //	int	work_pending;
 //
-//	spinlock_t lock;
+	spinlock_t lock;
+	u8 mac_addr[6];
 //
 //#ifdef CONFIG_ARCH_PXA
 //	/* DMA needs the physical address of the chip */
 //	u_long physaddr;
 //	struct device *device;
 //#endif
-//	void __iomem *base;
+	void __iomem *base;
 //	void __iomem *datacs;
 //
 
 	/* the low address lines on some platforms aren't connected... */
 	int	io_shift;
 
+	char name[IF_NAMESIZE + 1];
+
 	struct smc91x_platdata cfg;
 };
-
 
 
 #endif /* SMC91X_H_ */

--- a/core/include/drivers/smsc/smsc91x.h
+++ b/core/include/drivers/smsc/smsc91x.h
@@ -8,7 +8,189 @@
 #ifndef SMC91X_H_
 #define SMC91X_H_
 
+#include <stdint.h>
 
+#include <mm/core_mmu.h>
+
+#include <drivers/smsc/napi.h>
+
+#include <kernel/interrupt.h>
+
+#include <kernel/dt.h>
+
+#include "skbuff_stub.h"
+
+#include "sw_fec_state.h"
+
+#include <io.h>
+
+#include <drivers/smsc/bstgw_pktq.h>
+
+
+#define CARDNAME "smc91x"
+
+#define SMC_REG(smsc, reg, bank)	(reg<<SMC_IO_SHIFT)
+
+// Base Address Register
+/* BANK 1 */
+#define BASE_REG(lp)	SMC_REG(lp, 0x0002, 1)
+
+// Revision Register
+/* BANK 3 */
+/* ( hi: chip id   low: rev # ) */
+#define REV_REG(lp)		SMC_REG(lp, 0x000A, 3)
+
+#define SMC_GET_REV(lp)		SMC_inw(ioaddr, REV_REG(lp))
+
+#define SMC_CAN_USE_8BIT	1
+#define SMC_CAN_USE_16BIT	1
+#define SMC_CAN_USE_32BIT	1
+
+#define SMC91X_USE_8BIT (1 << 0)
+#define SMC91X_USE_16BIT (1 << 1)
+#define SMC91X_USE_32BIT (1 << 2)
+
+#define SMC91X_NOWAIT		(1 << 3)
+
+/* two bits for IO_SHIFT, let's hope later designs will keep this sane */
+#define SMC91X_IO_SHIFT_0	(0 << 4)
+#define SMC91X_IO_SHIFT_1	(1 << 4)
+#define SMC91X_IO_SHIFT_2	(2 << 4)
+#define SMC91X_IO_SHIFT_3	(3 << 4)
+#define SMC91X_IO_SHIFT(x)	(((x) >> 4) & 0x3)
+
+#define SMC91X_USE_DMA		(1 << 6)
+
+#define RPC_LED_100_10	(0x00)	/* LED = 100Mbps OR's with 10Mbps link detect */
+#define RPC_LED_RES	(0x01)	/* LED = Reserved */
+#define RPC_LED_10	(0x02)	/* LED = 10Mbps link detect */
+#define RPC_LED_FD	(0x03)	/* LED = Full Duplex Mode */
+#define RPC_LED_TX_RX	(0x04)	/* LED = TX or RX packet occurred */
+#define RPC_LED_100	(0x05)	/* LED = 100Mbps link dectect */
+#define RPC_LED_TX	(0x06)	/* LED = TX packet occurred */
+#define RPC_LED_RX	(0x07)	/* LED = RX packet occurred */
+
+#define SMC_inb(a, r)		io_read8((a) + (r))
+#define SMC_inw(a, r)		io_read16((a) + (r))
+#define SMC_inl(a, r)		io_read32((a) + (r))
+#define SMC_outb(v, a, r)	io_write8((a) + (r), v)
+#define SMC_outw(v, a, r)	io_write16((a) + (r), v)
+#define SMC_outl(v, a, r)	io_write32((a) + (r), v)
+//#define SMC_insw(a, r, p, l)	readsw((a) + (r), p, l)
+//#define SMC_outsw(a, r, p, l)	writesw((a) + (r), p, l)
+//#define SMC_insl(a, r, p, l)	readsl((a) + (r), p, l)
+//#define SMC_outsl(a, r, p, l)	writesl((a) + (r), p, l)
+
+
+#define SMC_IO_SHIFT		(smsc->io_shift)
+
+#define SMC_8BIT(p)	((p)->cfg.flags & SMC91X_USE_8BIT)
+#define SMC_16BIT(p)	((p)->cfg.flags & SMC91X_USE_16BIT)
+#define SMC_32BIT(p)	((p)->cfg.flags & SMC91X_USE_32BIT)
+
+/*
+ * Hack Alert: Some setups just can't write 8 or 16 bits reliably when not
+ * aligned to a 32 bit boundary.  I tell you that does exist!
+ * Fortunately the affected register accesses can be easily worked around
+ * since we can write zeroes to the preceeding 16 bits without adverse
+ * effects and use a 32-bit access.
+ *
+ * Enforce it on any 32-bit capable setup for now.
+ */
+#define SMC_MUST_ALIGN_WRITE(lp)	SMC_32BIT(lp)
+
+#define SMC_GET_BASE(lp)		SMC_inw(ioaddr, BASE_REG(lp))
+
+/*
+ . Bank Select Register:
+ .
+ .		yyyy yyyy 0000 00xx
+ .		xx 		= bank number
+ .		yyyy yyyy	= 0x33, for identification purposes.
+*/
+#define BANK_SELECT		(14 << SMC_IO_SHIFT)
+
+#define SMC_CURRENT_BANK(lp)	SMC_inw(ioaddr, BANK_SELECT)
+
+#define SMC_SELECT_BANK(lp, x)					\
+	do {								\
+		if (SMC_MUST_ALIGN_WRITE(lp))				\
+			SMC_outl((x)<<16, ioaddr, 12<<SMC_IO_SHIFT);	\
+		else							\
+			SMC_outw(x, ioaddr, BANK_SELECT);		\
+	} while (0)
+
+typedef unsigned int spinlock_t;
+
+/* Maximum number of queues supported */
+#define FEC_ENET_MAX_TX_QS	1
+#define FEC_ENET_MAX_RX_QS	1
+
+/* We assume 2 secure IRQs (plus 1 virtual IRQ for NW pass-on) */
+#define FEC_IRQ_NUM		3
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef unsigned short ushort;
+typedef unsigned int uint;
+
+struct smc91x_platdata {
+	unsigned long flags;
+	unsigned char leda;
+	unsigned char ledb;
+};
+
+struct smc_local {
+//	/*
+//	 * If I have to wait until memory is available to send a
+//	 * packet, I will store the skbuff here, until I get the
+//	 * desired memory.  Then, I'll send it out and free it.
+//	 */
+//	struct sk_buff *pending_tx_skb;
+//#if 0
+//	struct tasklet_struct tx_task;
+//#endif
+//
+//	/* version/revision of the SMC91x chip */
+//	int	version;
+//
+//	/* Contains the current active transmission mode */
+//	int	tcr_cur_mode;
+//
+//	/* Contains the current active receive mode */
+//	int	rcr_cur_mode;
+//
+//	/* Contains the current active receive/phy mode */
+//	int	rpc_cur_mode;
+//	int	ctl_rfduplx;
+//	int	ctl_rspeed;
+//
+//	u32	msg_enable;
+//	u32	phy_type;
+//	struct mii_if_info mii;
+//
+//	/* work queue */
+//	struct work_struct phy_configure;
+//	struct net_device *dev;
+//	int	work_pending;
+//
+//	spinlock_t lock;
+//
+//#ifdef CONFIG_ARCH_PXA
+//	/* DMA needs the physical address of the chip */
+//	u_long physaddr;
+//	struct device *device;
+//#endif
+//	void __iomem *base;
+//	void __iomem *datacs;
+//
+
+	/* the low address lines on some platforms aren't connected... */
+	int	io_shift;
+
+	struct smc91x_platdata cfg;
+};
 
 
 

--- a/core/include/drivers/smsc/smsc91x.h
+++ b/core/include/drivers/smsc/smsc91x.h
@@ -1,0 +1,15 @@
+/*
+ * smc91x.h
+ *
+ *  Created on: Nov 10, 2022
+ *      Author: rami
+ */
+
+#ifndef SMC91X_H_
+#define SMC91X_H_
+
+
+
+
+
+#endif /* SMC91X_H_ */

--- a/core/include/drivers/smsc/smsc91x_defs.h
+++ b/core/include/drivers/smsc/smsc91x_defs.h
@@ -1,0 +1,21 @@
+/*
+ * smsc91x_defs.h
+ *
+ *  Created on: Nov 14, 2022
+ *      Author: rami
+ */
+
+#ifndef SMSC91X_DEFS_H_
+#define SMSC91X_DEFS_H_
+
+#define SMC_inb(a, r)		io_read8((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_inw(a, r)		io_read16((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_inl(a, r)		io_read32((uintptr_t)(a) + (uintptr_t)(r))
+#define SMC_outb(v, a, r)	io_write8((uintptr_t)(a) + (uintptr_t)(r), v)
+#define SMC_outw(v, a, r)	io_write16((uintptr_t)(a) + (uintptr_t)(r), v)
+#define SMC_outl(v, a, r)	io_write32((uintptr_t)(a) + (uintptr_t)(r), v)
+
+
+
+
+#endif /* SMSC91X_DEFS_H_ */

--- a/core/include/drivers/smsc/sw_fec_state.h
+++ b/core/include/drivers/smsc/sw_fec_state.h
@@ -1,0 +1,57 @@
+#ifndef BSTGW_SW_FEC_STATE_H
+#define BSTGW_SW_FEC_STATE_H
+
+typedef enum {
+	/* error / pre-init */
+	SFEC_PRI_ERROR = -1,			// error
+	SFEC_PRI_UNINIT = 0,			// not yet initialized
+	
+	/* waiting for NW */
+	SFEC_PRI_PROBED,		// 0x1
+	SFEC_PRI_OPENING,		// 0x2
+	SFEC_PRI_POST_OPEN,		// 0x3
+
+	/* runtime */
+	SFEC_PRI_RESTARTED, 	// 0x4	// mii still active
+	SFEC_PRI_STOPPED,   	// 0x5	// mii still active
+	SFEC_PRI_RUNNING,		// 0x6
+
+	/* terminated */
+	SFEC_PRI_SHUTTING_DOWN, // 0x7
+	SFEC_PRI_SHUT_DOWN		// 0x8
+
+} sfec_prist_t;
+
+typedef enum {
+	SFEC_SUB_NONE = 0,
+
+	/* fec_restart */
+	SFEC_SUB_RESTART_RESET = 0x10,
+	SFEC_SUB_RESTART_INIT,			// 0x11
+	SFEC_SUB_RESTART_MII_MODE,		// 0x12
+	SFEC_SUB_RESTART_MII_SPEED,		// 0x13
+	SFEC_SUB_RESTART_FCE_EN, // todo! (skipped under certain conditions)
+	SFEC_SUB_RESTART_R_CNTRL,		// 0x14
+	SFEC_SUB_RESTART_ECNTRL,		// 0x15
+	SFEC_SUB_RESTART_IMASK_RUN,		// 0x16 	// fep->link
+	SFEC_SUB_RESTART_IMASK_MII,		// 0x17 	// !fep->link
+
+	/* fec_stop */
+	SFEC_SUB_STOP_GET_RMII = 0x20,
+	SFEC_SUB_STOP_XMIT_STOP,		// 0x21		// skipped iff (!fep->link)
+	SFEC_SUB_STOP_GET_IEVENT,		// 0x22 	// skipped iff (!fep->link)
+	SFEC_SUB_STOP_RESET,			// 0x23
+	SFEC_SUB_STOP_MII_IMASK,		// 0x24
+	SFEC_SUB_STOP_MII_SPEED,		// 0x25
+	SFEC_SUB_STOP_ECNTRL,			// 0x26
+	//SFEC_SUB_STOP_R_CNTRL,
+
+} sfec_subst_t;
+
+typedef struct bstgw_sec_fec_state {
+	sfec_prist_t primary_st;
+	sfec_subst_t sub_st;
+	uint32_t rcntl, ecntl, rmii_mode;
+} sfec_state_t;
+
+#endif /* BSTGW_SW_FEC_STATE_H */

--- a/core/include/drivers/smsc/utils.h
+++ b/core/include/drivers/smsc/utils.h
@@ -25,10 +25,12 @@
 #define	__arraycount(__x)	(sizeof(__x) / sizeof(__x[0]))
 #endif
 
+#ifdef SPCM_UNUSED
 static void bstgw_spin_cycles(unsigned int *count) {
     volatile unsigned int n = *count;
     while(__predict_true( n-- )) __asm volatile("yield" ::: "memory");
 }
+#endif
 
 #ifndef unlikely
 #define unlikely(x)      __builtin_expect(!!(x), 0)

--- a/core/include/drivers/smsc/utils.h
+++ b/core/include/drivers/smsc/utils.h
@@ -1,0 +1,119 @@
+#ifndef BSTGW_FEC_UTILS_H
+#define BSTGW_FEC_UTILS_H
+
+#include <stdlib.h>
+#include <mm/core_mmu.h>
+
+/*
+ * Branch prediction macros.
+ */
+
+#ifndef __predict_true
+#define	__predict_true(x)	__builtin_expect(!!(x), 1)
+#define	__predict_false(x)	__builtin_expect(!!(x), 0)
+#endif
+
+/*
+ * Various C helpers and attribute macros.
+ */
+
+#ifndef __unused
+#define	__unused		__attribute__((__unused__))
+#endif
+
+#ifndef __arraycount
+#define	__arraycount(__x)	(sizeof(__x) / sizeof(__x[0]))
+#endif
+
+static void bstgw_spin_cycles(unsigned int *count) {
+    volatile unsigned int n = *count;
+    while(__predict_true( n-- )) __asm volatile("yield" ::: "memory");
+}
+
+#ifndef unlikely
+#define unlikely(x)      __builtin_expect(!!(x), 0)
+#endif
+
+#ifndef likely
+#define likely(x)      __builtin_expect(!!(x), 1)
+#endif
+
+// taken from linux/err.h
+#define MAX_ERRNO   4095
+#define IS_ERR_VALUE(x) unlikely((unsigned long)(void *)(x) >= (unsigned long)-MAX_ERRNO)
+static inline bool IS_ERR(const void *ptr) {
+    return IS_ERR_VALUE((unsigned long)ptr);
+}
+
+// taken from linux/kernel.h
+/*
+ * This looks more complex than it should be. But we need to
+ * get the type for the ~ right in round_down (it needs to be
+ * as wide as the result!), and we want to evaluate the macro
+ * arguments just once each.
+ */
+#define __round_mask(x, y) ((__typeof__(x))((y)-1))
+#define round_up(x, y) ((((x)-1) | __round_mask(x, y))+1)
+#define round_down(x, y) ((x) & ~__round_mask(x, y))
+
+// linux/slab.h
+#define GFP_KERNEL (0)
+static inline void linux_kfree(void *p) { free(p); }
+static inline void *linux_kmalloc(size_t size, unsigned flags __unused) { return malloc(size); }
+static inline void *linux_kzalloc(size_t size, unsigned flags __unused) { return calloc(1, size); }
+
+/* helper functions */
+struct ifnet;
+struct ifnet * bstgw_alloc_etherdev(size_t);
+
+struct device;
+struct resource;
+enum resource_type;
+
+struct resource * bstgw_platform_get_resource(
+    struct device *, enum resource_type, unsigned int);
+
+vaddr_t bstgw_devm_ioremap_resource(struct resource *);
+
+
+#if defined(ARM32)
+#define BITS_PER_LONG 32
+#elif defined(ARM64)
+#define BITS_PER_LONG 64
+#else
+#error Unknown BITS_PER_LONG
+#endif
+
+// TODO: from Linux kernel __fls.h
+static __always_inline unsigned long __fls(unsigned long word)
+{
+	int num = BITS_PER_LONG - 1;
+
+#if BITS_PER_LONG == 64
+	if (!(word & (~0ul << 32))) {
+		num -= 32;
+		word <<= 32;
+	}
+#endif
+	if (!(word & (~0ul << (BITS_PER_LONG-16)))) {
+		num -= 16;
+		word <<= 16;
+	}
+	if (!(word & (~0ul << (BITS_PER_LONG-8)))) {
+		num -= 8;
+		word <<= 8;
+	}
+	if (!(word & (~0ul << (BITS_PER_LONG-4)))) {
+		num -= 4;
+		word <<= 4;
+	}
+	if (!(word & (~0ul << (BITS_PER_LONG-2)))) {
+		num -= 2;
+		word <<= 2;
+	}
+	if (!(word & (~0ul << (BITS_PER_LONG-1))))
+		num -= 1;
+	return num;
+}
+
+#endif /* BSTGW_FEC_UTILS_H */

--- a/core/include/kernel/interrupt.h
+++ b/core/include/kernel/interrupt.h
@@ -13,6 +13,11 @@
 #define ITRF_TRIGGER_LEVEL	BIT(0)
 #define ITRF_SHARED			BIT(1)
 
+struct irq_handler {
+	void *data;
+	enum irq_return (*handle)(struct irq_handler *h);
+};
+
 struct itr_chip {
 	const struct itr_ops *ops;
 	/*


### PR DESCRIPTION
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->

SMSC 91x Ethernet driver port from Xvisor
- Tested to work when called by sample pseudo TA
- Can work in an echo server mode (loopback interface for testing)
- Working interrupts
- Working Tx/Rx paths
- Working buffer management